### PR TITLE
Added config options to enable HTTPS and custom vhost names

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,7 @@
 CS_URL=http://localhost:8080
+PUBLIC_HOST=primate.example.com
+HTTPS_CERT=/etc/ssl/certs/primate.example.com.pem
+HTTPS_KEY=/etc/ssl/private/primate.example.com.key
+HTTPS_CA=/etc/ssl/certs/ca.pem
+HTTPS_DHPARAM=/etc/ssl/keys/dh2048.pem
+ALLOWED_HOSTS=["primate.example.com","cloud.example.com"]

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,1 @@
 CS_URL=http://localhost:8080
-PUBLIC_HOST=primate.example.com
-HTTPS_CERT=/etc/ssl/certs/primate.example.com.pem
-HTTPS_KEY=/etc/ssl/private/primate.example.com.key
-HTTPS_CA=/etc/ssl/certs/ca.pem
-HTTPS_DHPARAM=/etc/ssl/keys/dh2048.pem
-ALLOWED_HOSTS=["primate.example.com","cloud.example.com"]

--- a/vue.config.js
+++ b/vue.config.js
@@ -116,14 +116,14 @@ module.exports = {
         changeOrigin: true
       }
     },
-    public: process.env.PUBLIC_HOST,
+    public: process.env.PUBLIC_HOST || undefined,
     https: {
-      key: fs.readFileSync(process.env.HTTPS_KEY),
-      cert: fs.readFileSync(process.env.HTTPS_CERT),
-      ca: fs.readFileSync(process.env.HTTPS_CA),
-      dhparam: fs.readFileSync(process.env.HTTPS_DHPARAM)
+      key: process.env.HTTPS_KEY ? fs.readFileSync(process.env.HTTPS_KEY) : undefined,
+      cert: process.env.HTTPS_CERT ? fs.readFileSync(process.env.HTTPS_CERT) : undefined,
+      ca: process.env.HTTPS_CA ? fs.readFileSync(process.env.HTTPS_CA) : undefined,
+      dhparam: process.env.HTTPS_DHPARAM ? fs.readFileSync(process.env.HTTPS_DHPARAM) : undefined
     },
-    allowedHosts: JSON.parse(process.env.ALLOWED_HOSTS)
+    allowedHosts: process.env.ALLOWED_HOSTS ? JSON.parse(process.env.ALLOWED_HOSTS) : undefined
   },
 
   lintOnSave: undefined,

--- a/vue.config.js
+++ b/vue.config.js
@@ -17,6 +17,7 @@
 
 const path = require('path')
 const webpack = require('webpack')
+const fs = require('fs')
 
 function resolve (dir) {
   return path.join(__dirname, dir)
@@ -114,7 +115,15 @@ module.exports = {
         ws: false,
         changeOrigin: true
       }
-    }
+    },
+    public: process.env.PUBLIC_HOST,
+    https: {
+      key: fs.readFileSync(process.env.HTTPS_KEY),
+      cert: fs.readFileSync(process.env.HTTPS_CERT),
+      ca: fs.readFileSync(process.env.HTTPS_CA),
+      dhparam: fs.readFileSync(process.env.HTTPS_DHPARAM)
+    },
+    allowedHosts: JSON.parse(process.env.ALLOWED_HOSTS)
   },
 
   lintOnSave: undefined,


### PR DESCRIPTION
Moved from https://github.com/shapeblue/primate-old-do-not-use/pull/41 .

This PR is a proposed solution for https://github.com/shapeblue/primate-old-do-not-use/issues/37 .

Not everybody may want to configure HTTPS, it's probably necessary to make some of the env vars optional.