### PR TITLE
Remove vue.js standard eslint rule set

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
       "node": true
     },
     "extends": [
-      "plugin:vue/strongly-recommended",
-      "@vue/standard"
+      "plugin:vue/strongly-recommended"
     ],
     "parserOptions": {
       "parser": "babel-eslint"


### PR DESCRIPTION
**Caveat:** Mutually exclusive with #19 .

May address #18 - but doesn't really fix it.

The vue.js standard rule set causes a lot of errors on the Primate source code.
This PR removes the standard rule set and only keeps the strongly-recommended rules.