### PR TITLE
Add container build files and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:10-buster AS build
+
+WORKDIR /build
+
+RUN apt-get -y update && \
+	apt-get -y upgrade
+
+COPY . /build/
+RUN	npm install
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+
+LABEL org.opencontainers.image.title="CloudStack Primate" \
+	org.opencontainers.image.description="A modern role-based progressive CloudStack UI based on VueJS and Ant Design" \
+	org.opencontainers.image.authors="The Apache Software Foundation" \
+	org.opencontainers.image.url="https://github.com/apache/cloudstack-primate" \
+	org.opencontainers.image.documentation="https://github.com/apache/cloudstack-primate/README.md" \
+	org.opencontainers.image.source="https://github.com/apache/cloudstack-primate" \
+	org.opencontainers.image.vendor="The Apache Software Foundation" \
+	org.opencontainers.image.licenses="Apache-2.0" \
+	org.opencontainers.image.ref.name="latest"
+
+COPY --from=build /build/dist/. /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 FROM node:10-buster AS build
 
 WORKDIR /build
@@ -12,8 +29,8 @@ RUN npm run build
 FROM nginx:alpine AS runtime
 
 LABEL org.opencontainers.image.title="CloudStack Primate" \
-	org.opencontainers.image.description="A modern role-based progressive CloudStack UI based on VueJS and Ant Design" \
-	org.opencontainers.image.authors="The Apache Software Foundation" \
+	org.opencontainers.image.description="A modern role-based progressive CloudStack UI" \
+	org.opencontainers.image.authors="Apache CloudStack Contributors" \
 	org.opencontainers.image.url="https://github.com/apache/cloudstack-primate" \
 	org.opencontainers.image.documentation="https://github.com/apache/cloudstack-primate/README.md" \
 	org.opencontainers.image.source="https://github.com/apache/cloudstack-primate" \

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Fix issues and vulnerabilities:
 
     npm audit
 
+### Docker
+
+A production-ready Docker container can also be built with the provided
+Dockerfile and build script.
+
+Make sure Docker is installed, then run build.sh:
+
+    ./build.sh
+
+Change the example configuration in `nginx/default.conf` according to your needs.
+
+Run Primate:
+
+    docker run -ti --rm -p 8080:80 -v $(pwd)/nginx:/etc/nginx/conf.d:ro cloudstack-primate:latest
+
 ## Documentation
 
 ### Learning Resources

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,20 @@
-#!/bin/sh
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 set -e
 set -x

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+set -x
+
+GIT_TAG="$(git tag --points-at | head -n 1)"
+if [ -n "${GIT_REV}" ]; then
+	LABEL_GIT_TAG="--label \"org.opencontainers.image.version=${GIT_TAG}\""
+fi
+DATE="$(date --iso-8601=seconds)"
+LABEL_DATE="--label \"org.opencontainers.image.created=${DATE}\""
+GIT_REV="$(git rev-parse HEAD)"
+LABEL_GIT_REV="--label \"org.opencontainers.image.revision=${GIT_REV}\""
+
+docker build -t cloudstack-primate ${LABEL_DATE} ${LABEL_GIT_REV} ${LABEL_GIT_TAG} .

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 server {
     listen       80;
     server_name  localhost;
@@ -6,8 +23,8 @@ server {
         index  index.html;
     }
     location /client/ {
-        # http://127.0.0.1:800 should be replaced your CloudStack management
-        # server's actual URI
-        proxy_pass   http://127.0.0.1:8000;
+        # http://127.0.0.1:8080 should be replaced your CloudStack management
+        # Server's actual URI
+        proxy_pass   http://127.0.0.1:8080;
     }
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,13 @@
+server {
+    listen       80;
+    server_name  localhost;
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+    }
+    location /client/ {
+        # http://127.0.0.1:800 should be replaced your CloudStack management
+        # server's actual URI
+        proxy_pass   http://127.0.0.1:8000;
+    }
+}


### PR DESCRIPTION
(as discussed in #12 )

This PR adds:
* a Dockerfile
* a build script that injects some labels from git
* an example nginx config for running the built webpack
* instructions on how to run the container