### PR TITLE
Change CRLF editor config to LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 charset=utf-8
-end_of_line=crlf
+end_of_line=lf
 insert_final_newline=false
 indent_style=space
 indent_size=2


### PR DESCRIPTION
Practically all files in the repository have UNIX (LF) line endings.
This contradicts the CRLF policy in .editorconfig and is causing problems with all editors that honour the editor config.

This PR replaces the CRLF policy with LF.