### PR TITLE
config: fix existing access values display for update offering access

### DIFF
--- a/src/views/offering/UpdateOfferingAccess.vue
+++ b/src/views/offering/UpdateOfferingAccess.vue
@@ -163,6 +163,7 @@ export default {
         this.domains = this.domains.concat(listDomains)
       }).finally(() => {
         this.domainLoading = false
+        this.updateDomainSelection()
       })
     },
     fetchZoneData () {
@@ -174,6 +175,7 @@ export default {
         this.zones = this.zones.concat(listZones)
       }).finally(() => {
         this.zoneLoading = false
+        this.updateZoneSelection()
       })
     },
     updateDomainSelection () {


### PR DESCRIPTION
This PR fixes showing existing domain and zone values in update offering access form.
![Screenshot from 2020-01-06 13-19-57](https://user-images.githubusercontent.com/153340/72235284-4c35a600-35f7-11ea-8ff1-62f3ebb8c85b.png)
