### PR TITLE
Disabling edit settings when the vm is running

### DIFF
--- a/src/components/view/DetailSettings.vue
+++ b/src/components/view/DetailSettings.vue
@@ -17,10 +17,14 @@
 
 <template>
   <a-spin :spinning="loading">
-    <div v-show="!showAddDetail">
+    <a-alert
+      message="Please stop the virtual machine to access settings"
+      banner
+      :hidden="!disableEditSettings" />
+    <div v-show="!showAddDetail" :hidden="disableEditSettings">
       <a-button type="dashed" style="width: 100%" icon="plus" @click="showAddDetail = true">Add Setting</a-button>
     </div>
-    <div v-show="showAddDetail">
+    <div v-show="showAddDetail" :hidden="disableEditSettings">
       <a-auto-complete
         style="width: 100%"
         :filterOption="filterOption"
@@ -56,7 +60,7 @@
             <span v-else @click="showEditDetail(index)">{{ item.value }}</span>
           </span>
         </a-list-item-meta>
-        <div slot="actions">
+        <div slot="actions" :hidden="disableEditSettings">
           <a-button shape="circle" size="default" @click="updateDetail(index)" v-if="item.edit">
             <a-icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" />
           </a-button>
@@ -67,7 +71,7 @@
             <a-icon type="edit" />
           </a-button>
         </div>
-        <div slot="actions">
+        <div slot="actions" :hidden="disableEditSettings">
           <a-popconfirm
             title="Delete setting?"
             @confirm="deleteDetail(index)"
@@ -101,6 +105,7 @@ export default {
       details: [],
       detailOptions: {},
       showAddDetail: false,
+      disableEditSettings: false,
       newKey: '',
       newValue: '',
       loading: false,
@@ -136,6 +141,7 @@ export default {
       api('listDetailOptions', { resourcetype: this.resourceType, resourceid: this.resource.id }).then(json => {
         this.detailOptions = json.listdetailoptionsresponse.detailoptions.details
       })
+      this.disableEditSettings = this.$route.meta.name === 'vm' && this.resource.state === 'Running'
     },
     showEditDetail (index) {
       this.details[index].edit = true

--- a/src/components/view/DetailSettings.vue
+++ b/src/components/view/DetailSettings.vue
@@ -16,15 +16,15 @@
 // under the License.
 
 <template>
-  <a-spin :spinning="loading">
-    <a-alert
-      message="Please stop the virtual machine to access settings"
-      banner
-      :hidden="!disableEditSettings" />
-    <div v-show="!showAddDetail" :hidden="disableEditSettings">
+  <a-alert
+    v-if="disableSettings"
+    banner
+    message="Please stop the virtual machine to access settings" />
+  <a-spin v-else :spinning="loading">
+    <div v-show="!showAddDetail">
       <a-button type="dashed" style="width: 100%" icon="plus" @click="showAddDetail = true">Add Setting</a-button>
     </div>
-    <div v-show="showAddDetail" :hidden="disableEditSettings">
+    <div v-show="showAddDetail">
       <a-auto-complete
         style="width: 100%"
         :filterOption="filterOption"
@@ -60,7 +60,7 @@
             <span v-else @click="showEditDetail(index)">{{ item.value }}</span>
           </span>
         </a-list-item-meta>
-        <div slot="actions" :hidden="disableEditSettings">
+        <div slot="actions">
           <a-button shape="circle" size="default" @click="updateDetail(index)" v-if="item.edit">
             <a-icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" />
           </a-button>
@@ -71,7 +71,7 @@
             <a-icon type="edit" />
           </a-button>
         </div>
-        <div slot="actions" :hidden="disableEditSettings">
+        <div slot="actions">
           <a-popconfirm
             title="Delete setting?"
             @confirm="deleteDetail(index)"
@@ -105,7 +105,7 @@ export default {
       details: [],
       detailOptions: {},
       showAddDetail: false,
-      disableEditSettings: false,
+      disableSettings: false,
       newKey: '',
       newValue: '',
       loading: false,
@@ -141,7 +141,7 @@ export default {
       api('listDetailOptions', { resourcetype: this.resourceType, resourceid: this.resource.id }).then(json => {
         this.detailOptions = json.listdetailoptionsresponse.detailoptions.details
       })
-      this.disableEditSettings = this.$route.meta.name === 'vm' && this.resource.state === 'Running'
+      this.disableSettings = (this.$route.meta.name === 'vm' && this.resource.state !== 'Stopped')
     },
     showEditDetail (index) {
       this.details[index].edit = true

--- a/src/components/view/DetailSettings.vue
+++ b/src/components/view/DetailSettings.vue
@@ -16,31 +16,33 @@
 // under the License.
 
 <template>
-  <a-alert
-    v-if="disableSettings"
-    banner
-    message="Please stop the virtual machine to access settings" />
-  <a-spin v-else :spinning="loading">
-    <div v-show="!showAddDetail">
-      <a-button type="dashed" style="width: 100%" icon="plus" @click="showAddDetail = true">Add Setting</a-button>
-    </div>
-    <div v-show="showAddDetail">
-      <a-auto-complete
-        style="width: 100%"
-        :filterOption="filterOption"
-        :value="newKey"
-        :dataSource="Object.keys(detailOptions)"
-        placeholder="Name"
-        @change="e => onAddInputChange(e, 'newKey')" />
-      <a-auto-complete
-        style="width: 100%"
-        :filterOption="filterOption"
-        :value="newValue"
-        :dataSource="detailOptions[newKey]"
-        placeholder="Value"
-        @change="e => onAddInputChange(e, 'newValue')" />
-      <a-button type="primary" style="width: 25%" icon="plus" @click="addDetail">Add Setting</a-button>
-      <a-button type="dashed" style="width: 25%" icon="close" @click="showAddDetail = false">Cancel</a-button>
+  <a-spin :spinning="loading">
+    <a-alert
+      v-if="disableSettings"
+      banner
+      message="Please stop the virtual machine to access settings" />
+    <div v-else>
+      <div v-show="!showAddDetail">
+        <a-button type="dashed" style="width: 100%" icon="plus" @click="showAddDetail = true">Add Setting</a-button>
+      </div>
+      <div v-show="showAddDetail">
+        <a-auto-complete
+          style="width: 100%"
+          :filterOption="filterOption"
+          :value="newKey"
+          :dataSource="Object.keys(detailOptions)"
+          placeholder="Name"
+          @change="e => onAddInputChange(e, 'newKey')" />
+        <a-auto-complete
+          style="width: 100%"
+          :filterOption="filterOption"
+          :value="newValue"
+          :dataSource="detailOptions[newKey]"
+          placeholder="Value"
+          @change="e => onAddInputChange(e, 'newValue')" />
+        <a-button type="primary" style="width: 25%" icon="plus" @click="addDetail">Add Setting</a-button>
+        <a-button type="dashed" style="width: 25%" icon="close" @click="showAddDetail = false">Cancel</a-button>
+      </div>
     </div>
     <a-list size="large">
       <a-list-item :key="index" v-for="(item, index) in details">
@@ -60,7 +62,7 @@
             <span v-else @click="showEditDetail(index)">{{ item.value }}</span>
           </span>
         </a-list-item-meta>
-        <div slot="actions">
+        <div slot="actions" v-if="!disableSettings">
           <a-button shape="circle" size="default" @click="updateDetail(index)" v-if="item.edit">
             <a-icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" />
           </a-button>
@@ -71,7 +73,7 @@
             <a-icon type="edit" />
           </a-button>
         </div>
-        <div slot="actions">
+        <div slot="actions" v-if="!disableSettings">
           <a-popconfirm
             title="Delete setting?"
             @confirm="deleteDetail(index)"


### PR DESCRIPTION
Ensures that the vm settings are read only when the vm is running
This fixes #161 