### PR TITLE
view: fix archiveEvents router redirect

### DIFF
--- a/src/views/AutogenView.vue
+++ b/src/views/AutogenView.vue
@@ -742,7 +742,7 @@ export default {
                 break
               }
             }
-            if (this.currentAction.icon === 'delete' && this.dataView) {
+            if ((this.currentAction.icon === 'delete' || ['archiveEvents'].includes(this.currentAction.api)) && this.dataView) {
               this.$router.go(-1)
             } else {
               if (!hasJobId) {


### PR DESCRIPTION
Fixes #191 

After archiving event page is moved back to events list