### PR TITLE
view: reset listview count on list API call

### DIFF
--- a/src/views/AutogenView.vue
+++ b/src/views/AutogenView.vue
@@ -457,6 +457,7 @@ export default {
             break
           }
         }
+        this.itemCount = 0
         for (const key in json[responseName]) {
           if (key === 'count') {
             this.itemCount = json[responseName].count


### PR DESCRIPTION
Fixes #258 

Reset items count for listview while calling a list API to prevent wrong pagination on empty list in response

![Screenshot from 2020-03-31 16-02-31](https://user-images.githubusercontent.com/153340/78016899-120fb100-7369-11ea-9317-7fa4ccdc7d99.png)
