### PR TITLE
added color changes for different progress value

### DIFF
--- a/src/views/dashboard/CapacityDashboard.vue
+++ b/src/views/dashboard/CapacityDashboard.vue
@@ -57,9 +57,10 @@
               <h4>{{ $t(stat.name) }}</h4>
               <a-progress
                 type="dashboard"
-                :status="getStatus(parseFloat(stat.percentused))"
-                :percent="parseFloat(stat.percentused)"
+                :status="getStatus(parseFloat(stat.percentused, 10))"
+                :percent="parseFloat(stat.percentused, 10)"
                 :format="percent => `${parseFloat(stat.percentused, 10).toFixed(2)}%`"
+                :strokeColor="getStrokeColor(parseFloat(stat.percentused, 10))"
                 :width="100" />
             </div>
             <template slot="footer"><center>{{ displayData(stat.name, stat.capacityused) }} / {{ displayData(stat.name, stat.capacitytotal) }}</center></template>
@@ -164,6 +165,24 @@ export default {
         return 'active'
       }
       return 'normal'
+    },
+    getStrokeColor (value) {
+      if (value > 100) {
+        return '#cf1322'
+      }
+      if (value > 85) {
+        return '#f5222d'
+      }
+      if (value > 80) {
+        return '#ff4d4f'
+      }
+      if (value > 75) {
+        return '#fa541c'
+      }
+      if (value > 25) {
+        return '#2db7f5'
+      }
+      return '#52c41a'
     },
     displayData (dataType, value) {
       switch (dataType) {

--- a/src/views/dashboard/CapacityDashboard.vue
+++ b/src/views/dashboard/CapacityDashboard.vue
@@ -167,7 +167,7 @@ export default {
       return 'normal'
     },
     getStrokeColor (value) {
-      if (value > 80) {
+      if (value >= 80) {
         return 'red'
       }
       return '#1890ff'

--- a/src/views/dashboard/CapacityDashboard.vue
+++ b/src/views/dashboard/CapacityDashboard.vue
@@ -167,22 +167,10 @@ export default {
       return 'normal'
     },
     getStrokeColor (value) {
-      if (value > 100) {
-        return '#cf1322'
-      }
-      if (value > 85) {
-        return '#f5222d'
-      }
       if (value > 80) {
-        return '#ff4d4f'
+        return 'red'
       }
-      if (value > 75) {
-        return '#fa541c'
-      }
-      if (value > 25) {
-        return '#2db7f5'
-      }
-      return '#52c41a'
+      return '#1890ff'
     },
     displayData (dataType, value) {
       switch (dataType) {

--- a/src/views/dashboard/CapacityDashboard.vue
+++ b/src/views/dashboard/CapacityDashboard.vue
@@ -60,7 +60,7 @@
                 :status="getStatus(parseFloat(stat.percentused))"
                 :percent="parseFloat(stat.percentused)"
                 :format="percent => `${parseFloat(stat.percentused).toFixed(2)}%`"
-                :strokeColor="getStrokeColor(parseFloat(stat.percentused))"
+                :strokeColor="getStrokeColour(parseFloat(stat.percentused))"
                 :width="100" />
             </div>
             <template slot="footer"><center>{{ displayData(stat.name, stat.capacityused) }} / {{ displayData(stat.name, stat.capacitytotal) }}</center></template>
@@ -166,11 +166,11 @@ export default {
       }
       return 'normal'
     },
-    getStrokeColor (value) {
+    getStrokeColour (value) {
       if (value >= 80) {
         return 'red'
       }
-      return '#1890ff'
+      return 'primary'
     },
     displayData (dataType, value) {
       switch (dataType) {

--- a/src/views/dashboard/CapacityDashboard.vue
+++ b/src/views/dashboard/CapacityDashboard.vue
@@ -57,10 +57,10 @@
               <h4>{{ $t(stat.name) }}</h4>
               <a-progress
                 type="dashboard"
-                :status="getStatus(parseFloat(stat.percentused, 10))"
-                :percent="parseFloat(stat.percentused, 10)"
-                :format="percent => `${parseFloat(stat.percentused, 10).toFixed(2)}%`"
-                :strokeColor="getStrokeColor(parseFloat(stat.percentused, 10))"
+                :status="getStatus(parseFloat(stat.percentused))"
+                :percent="parseFloat(stat.percentused)"
+                :format="percent => `${parseFloat(stat.percentused).toFixed(2)}%`"
+                :strokeColor="getStrokeColor(parseFloat(stat.percentused))"
                 :width="100" />
             </div>
             <template slot="footer"><center>{{ displayData(stat.name, stat.capacityused) }} / {{ displayData(stat.name, stat.capacitytotal) }}</center></template>


### PR DESCRIPTION
Fixes #308 

```
value >= 80 : 'red'
default: '#1890ff'
```

Default colour value from here, https://github.com/apache/cloudstack-primate/blob/master/vue.config.js#L102