### PR TITLE
 Allow configuring IPv6 default guest network when deploying a new Zone

### DIFF
--- a/src/views/infra/zone/ZoneWizardZoneDetailsStep.vue
+++ b/src/views/infra/zone/ZoneWizardZoneDetailsStep.vue
@@ -81,7 +81,7 @@
       <a-form-item
         :label="$t('label.ipv6.dns1')"
         v-bind="formItemLayout"
-        v-if="isAdvancedZone && !securityGroupsEnabled"
+        v-if="isAdvancedZone"
         has-feedback>
         <a-input
           v-decorator="['ipv6Dns1', {
@@ -102,7 +102,7 @@
       <a-form-item
         :label="$t('label.ipv6.dns2')"
         v-bind="formItemLayout"
-        v-if="isAdvancedZone && !securityGroupsEnabled"
+        v-if="isAdvancedZone"
         has-feedback>
         <a-input
           v-decorator="['ipv6Dns2', {
@@ -120,6 +120,43 @@
           }]"
         />
       </a-form-item>
+      <a-form-item
+        :label="$t('ip6cidr')"
+        v-bind="formItemLayout"
+        v-if="isAdvancedZone && securityGroupsEnabled"
+        has-feedback>
+        <a-input
+          v-decorator="['ipv6Cidr', {
+            rules: [
+              {
+                message: 'Please enter IpV6 CIDR',
+                initialValue: ip6cidr
+              }
+            ]
+          }]"
+        />
+      </a-form-item>
+            <a-form-item
+              :label="$t('ip6gateway')"
+              v-bind="formItemLayout"
+              v-if="isAdvancedZone && securityGroupsEnabled"
+              has-feedback>
+              <a-input
+                v-decorator="['ip6gateway', {
+                  rules: [
+                    {
+                      message: 'Please enter IpV6 Gateway',
+                      initialValue: ip6gateway
+                    },
+                    {
+                      validator: checkIpFormat,
+                      ipV6: true,
+                      message: 'Please enter a valid IPv6 Gatweay.'
+                    }
+                  ]
+                }]"
+              />
+            </a-form-item>
       <a-form-item
         :label="$t('label.internal.dns.1')"
         v-bind="formItemLayout"

--- a/src/views/infra/zone/ZoneWizardZoneDetailsStep.vue
+++ b/src/views/infra/zone/ZoneWizardZoneDetailsStep.vue
@@ -121,7 +121,7 @@
         />
       </a-form-item>
       <a-form-item
-        :label="$t('ip6cidr')"
+        :label="$t('label.ip6cidr')"
         v-bind="formItemLayout"
         v-if="isAdvancedZone && securityGroupsEnabled"
         has-feedback>
@@ -137,7 +137,7 @@
         />
       </a-form-item>
             <a-form-item
-              :label="$t('ip6gateway')"
+              :label="$t('label.ip6gateway')"
               v-bind="formItemLayout"
               v-if="isAdvancedZone && securityGroupsEnabled"
               has-feedback>


### PR DESCRIPTION
Advanced Network with Security Groups is a great option for deploying a Zone with IPv6 address support. However, it is not possible to set IPv6 DNS + IPv6 CIDR + IPv6 gateway via the zoneWizard UI.

This PR adds a small enhancement on the UI Zone deployment to allow deploying a Zone with Advanced Network with Security Groups + IPv6 CIDR, IPv6 gateway, and IPv6 DNS.

Note that API [1] offers full support for such action, therefore there is no need for changing the API. It is just a small enhancement on UI that might be useful in the meantime that we wait for the new ACS UI.

[1] https://cloudstack.apache.org/api/apidocs-4.13/apis/createNetwork.html
![image](https://user-images.githubusercontent.com/5025148/82134208-d1aaac00-97cb-11ea-8001-1338d3cb2a5d.png)