### PR TITLE
Fix for secondary storage form - zone id

### DIFF
--- a/src/views/infra/AddSecondaryStorage.vue
+++ b/src/views/infra/AddSecondaryStorage.vue
@@ -47,6 +47,7 @@
                   initialValue: this.zoneSelected,
                   rules: [{ required: true, message: 'required'}]
                 }]"
+              @change="val => { zoneSelected = val }"
             >
               <a-select-option
                 :value="zone.id"
@@ -195,7 +196,7 @@ export default {
         if (json && json.listzonesresponse && json.listzonesresponse.zone) {
           this.zones = json.listzonesresponse.zone
           if (this.zones.length > 0) {
-            this.zoneSelected = this.zones[0].name
+            this.zoneSelected = this.zones[0].id || ''
           }
         }
       })


### PR DESCRIPTION
Zone name being passed instead of zone id
Addresses issue : https://github.com/apache/cloudstack-primate/issues/344