### PR TITLE
Fixing unable to log into legacy UI while primate is logged in

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -89,7 +89,6 @@ const user = {
           Cookies.set('account', result.account, { expires: 1 })
           Cookies.set('domainid', result.domainid, { expires: 1 })
           Cookies.set('role', result.type, { expires: 1 })
-          Cookies.set('sessionkey', result.sessionkey, { expires: 1 })
           Cookies.set('timezone', result.timezone, { expires: 1 })
           Cookies.set('timezoneoffset', result.timezoneoffset, { expires: 1 })
           Cookies.set('userfullname', result.firstname + ' ' + result.lastname, { expires: 1 })


### PR DESCRIPTION
This removes the `sessionkey` cookie which is passed via the legacy UI that causes credential auth issues
Fixes https://github.com/apache/cloudstack/issues/4136