### PR TITLE
Internationalize state output

### DIFF
--- a/src/components/widgets/Status.vue
+++ b/src/components/widgets/Status.vue
@@ -38,7 +38,37 @@ export default {
   methods: {
     getText () {
       if (this.displayText && this.text) {
-        return this.text.charAt(0).toUpperCase() + this.text.slice(1)
+        var state = this.text
+        switch (state) {
+          case 'Running':
+            state = this.$t('state.running')
+            break
+          case 'Stopped':
+            state = this.$t('state.stopped')
+            break
+          case 'Starting':
+            state = this.$t('state.starting')
+            break
+          case 'Stopping':
+            state = this.$t('state.stopping')
+            break
+          case 'Suspended':
+            state = this.$t('state.suspended')
+            break
+          case 'Pending':
+            state = this.$t('state.pending')
+            break
+          case 'Migrating':
+            state = this.$t('state.migrating')
+            break
+          case 'Expunging':
+            state = this.$t('state.expunging')
+            break
+          case 'Error':
+            state = this.$t('state.error')
+            break
+        }
+        return state.charAt(0).toUpperCase() + state.slice(1)
       }
       return ''
     },


### PR DESCRIPTION
CloudStack API methods return resources states in English, switching Primate to a different language should also translate these states.

Example: VM states: Running, Stopped, Migrating,...

![image](https://user-images.githubusercontent.com/5295080/86536532-ce27cd00-bebe-11ea-87a4-d7c079539435.png)
![image](https://user-images.githubusercontent.com/5295080/86536536-da138f00-bebe-11ea-8865-60b0751b5404.png)
