### PR TITLE
vm: Simplifying Deploy VM Wizard

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1403,6 +1403,7 @@
 "label.overprovisionfactor": "Overprovisioning Factor",
 "label.override.guest.traffic": "Override Guest-Traffic",
 "label.override.public.traffic": "Override Public-Traffic",
+"label.override.rootdisk.size": "Override Root Disk Size",
 "label.overrideguesttraffic": "Override Guest-Traffic",
 "label.overridepublictraffic": "Override Public-Traffic",
 "label.ovf.properties": "OVF Properties",

--- a/src/views/compute/wizard/AffinityGroupSelection.vue
+++ b/src/views/compute/wizard/AffinityGroupSelection.vue
@@ -17,6 +17,7 @@
 
 <template>
   <div>
+    {{ $t('message.select.affinity.groups') }}
     <a-input-search
       style="width: 25vw;float: right;margin-bottom: 10px; z-index: 8"
       :placeholder="$t('label.search')"

--- a/src/views/compute/wizard/DiskSizeSelection.vue
+++ b/src/views/compute/wizard/DiskSizeSelection.vue
@@ -20,24 +20,17 @@
     :label="inputDecorator === 'rootdisksize' ? $t('label.root.disk.size') : $t('label.disksize')"
     class="form-item">
     <a-row :gutter="12">
-      <a-col :md="10" :lg="10">
-        <a-slider
-          :min="0"
-          :max="1024"
-          v-model="inputValue"
-          @change="($event) => updateDiskSize($event)"
-        />
-      </a-col>
       <a-col :md="4" :lg="4">
         <span style="display: inline-flex">
           <a-input-number
             v-model="inputValue"
             @change="($event) => updateDiskSize($event)"
           />
-          <span style="padding-top: 6px">GB</span>
+          <span style="padding-top: 6px; margin-left: 5px">GB</span>
         </span>
       </a-col>
     </a-row>
+    <p v-if="error" style="color: red"> {{ $t(error) }} </p>
   </a-form-item>
 </template>
 
@@ -52,11 +45,23 @@ export default {
     preFillContent: {
       type: Object,
       default: () => {}
+    },
+    minDiskSize: {
+      type: Number,
+      default: 0
+    }
+  },
+  watch: {
+    minDiskSize (newItem) {
+      if (this.inputValue < newItem) {
+        this.inputValue = newItem
+      }
     }
   },
   data () {
     return {
-      inputValue: 0
+      inputValue: 0,
+      error: false
     }
   },
   mounted () {
@@ -64,14 +69,21 @@ export default {
   },
   methods: {
     fillValue () {
+      this.inputValue = this.minDiskSize
       if (this.inputDecorator === 'rootdisksize') {
-        this.inputValue = this.preFillContent.rootdisksize ? this.preFillContent.rootdisksize : 0
+        this.inputValue = this.preFillContent.rootdisksize ? this.preFillContent.rootdisksize : this.minDiskSize
       } else if (this.inputDecorator === 'size') {
-        this.inputValue = this.preFillContent.size ? this.preFillContent.size : 0
+        this.inputValue = this.preFillContent.size ? this.preFillContent.size : this.minDiskSize
       }
       this.$emit('update-disk-size', this.inputDecorator, this.inputValue)
     },
     updateDiskSize (value) {
+      if (value < this.minDiskSize) {
+        this.inputValue = this.minDiskSize
+        this.error = 'The value must not be less than ' + this.minDiskSize + ' GB'
+        return
+      }
+      this.error = false
       this.$emit('update-disk-size', this.inputDecorator, value)
     }
   }


### PR DESCRIPTION
Fixes #490
Fixes #491 
 
- Moves Affinity Group selection to Details
- Sets the minimum of the root disk size sider to the template size
- Adds a switch to show / hide details
- Adds a switch to show / hide root disk size slider

![Screenshot from 2020-07-06 19-29-36](https://user-images.githubusercontent.com/8244774/86601638-3231ba80-bfbf-11ea-9915-94143c732405.png)
![Screenshot from 2020-07-06 19-29-47](https://user-images.githubusercontent.com/8244774/86601645-3362e780-bfbf-11ea-8a0d-ca58c7b4b3c9.png)
![Screenshot from 2020-07-06 19-44-39](https://user-images.githubusercontent.com/8244774/86603111-365ed780-bfc1-11ea-924e-8279cc5b61c8.png)
![Screenshot from 2020-07-06 19-44-54](https://user-images.githubusercontent.com/8244774/86603113-36f76e00-bfc1-11ea-9e6e-ca384c3c06d6.png)


