### PR TITLE
Display URL for the template to admins

### DIFF
--- a/src/config/section/image.js
+++ b/src/config/section/image.js
@@ -42,7 +42,7 @@ export default {
         }
         return fields
       },
-      details: ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled', 'sshkeyenabled', 'directdownload', 'isextractable', 'isdynamicallyscalable', 'ispublic', 'isfeatured', 'crosszones', 'type', 'account', 'domain', 'created'],
+      details: ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled', 'sshkeyenabled', 'directdownload', 'isextractable', 'isdynamicallyscalable', 'ispublic', 'isfeatured', 'crosszones', 'type', 'account', 'domain', 'created', 'url'],
       searchFilters: ['name', 'zoneid', 'tags'],
       related: [{
         name: 'vm',


### PR DESCRIPTION
In legacy UI, we display the url of the template to
admins. Do the same thing here also

Below is the view for admin

![Screenshot 2020-07-09 at 11 25 07](https://user-images.githubusercontent.com/10645273/87023527-1ce3a880-c1d8-11ea-9111-f7c7c12013ff.png)


And below is the view for domain admins/users

![Screenshot 2020-07-09 at 11 24 04](https://user-images.githubusercontent.com/10645273/87023558-28cf6a80-c1d8-11ea-9879-a09d9906638d.png)
