### PR TITLE
Bug fixes

### DIFF
--- a/src/components/view/InfoCard.vue
+++ b/src/components/view/InfoCard.vue
@@ -374,7 +374,8 @@
           <div class="resource-detail-item__label">{{ $t('label.serviceofferingname') }}</div>
           <div class="resource-detail-item__details">
             <a-icon type="cloud" />
-            <router-link v-if="$router.resolve('/computeoffering/' + resource.serviceofferingid).route.name !== '404'" :to="{ path: '/computeoffering/' + resource.serviceofferingid }">{{ resource.serviceofferingname || resource.serviceofferingid }} </router-link>
+            <router-link v-if="$route.meta.name === 'router'" :to="{ path: '/computeoffering/' + resource.serviceofferingid, query: { issystem: true } }">{{ resource.serviceofferingname || resource.serviceofferingid }} </router-link>
+            <router-link v-else-if="$router.resolve('/computeoffering/' + resource.serviceofferingid).route.name !== '404'" :to="{ path: '/computeoffering/' + resource.serviceofferingid }">{{ resource.serviceofferingname || resource.serviceofferingid }} </router-link>
             <span v-else>{{ resource.serviceofferingname || resource.serviceofferingid }}</span>
           </div>
         </div>

--- a/src/components/view/ListView.vue
+++ b/src/components/view/ListView.vue
@@ -81,9 +81,10 @@
     <a slot="displayname" slot-scope="text, record" href="javascript:;">
       <router-link :to="{ path: $route.path + '/' + record.id }">{{ text }}</router-link>
     </a>
-    <a slot="username" slot-scope="text, record" href="javascript:;">
-      <router-link :to="{ path: $route.path + '/' + record.id }">{{ text }}</router-link>
-    </a>
+    <span slot="username" slot-scope="text, record" href="javascript:;">
+      <router-link :to="{ path: '/accountuser', query: { username: record.username, domainid: record.domainid } }" v-if="$store.getters.userInfo.roletype !== 'User'">{{ text }}</router-link>
+      <span v-else>{{ text }}</span>
+    </span>
     <a slot="ipaddress" slot-scope="text, record" href="javascript:;">
       <router-link :to="{ path: $route.path + '/' + record.id }">{{ text }}</router-link>
       <span v-if="record.issourcenat">

--- a/src/config/section/infra/systemVms.js
+++ b/src/config/section/infra/systemVms.js
@@ -56,7 +56,13 @@ export default {
       message: 'message.confirm.scale.up.system.vm',
       dataView: true,
       show: (record) => { return record.hypervisor !== 'KVM' },
-      args: ['serviceofferingid']
+      args: ['serviceofferingid'],
+      mapping: {
+        serviceofferingid: {
+          api: 'listServiceOfferings',
+          params: (record) => { return { virtualmachineid: record.virtualmachineid, issystem: true, systemvmtype: record.systemvmtype } }
+        }
+      }
     },
     {
       api: 'migrateSystemVm',

--- a/src/views/compute/wizard/DiskOfferingSelection.vue
+++ b/src/views/compute/wizard/DiskOfferingSelection.vue
@@ -157,10 +157,8 @@ export default {
       }
     },
     items (newData, oldData) {
-      if (newData && newData.length > 0) {
-        this.initDataItem()
-        this.dataItems = this.dataItems.concat(newData)
-      }
+      this.initDataItem()
+      this.dataItems = this.dataItems.concat(newData)
     },
     loading () {
       if (!this.loading) {

--- a/src/views/network/AclListRulesTab.vue
+++ b/src/views/network/AclListRulesTab.vue
@@ -133,7 +133,7 @@
     <a-modal :title="ruleModalTitle" v-model="ruleModalVisible" @ok="handleRuleModalForm">
       <a-form :form="ruleForm" @submit="handleRuleModalForm">
         <a-form-item :label="$t('label.number')">
-          <a-input v-decorator="['number']" />
+          <a-input-number style="width: 100%" v-decorator="['number']" />
         </a-form-item>
         <a-form-item :label="$t('label.cidrlist')">
           <a-input v-decorator="['cidr']" />

--- a/src/views/network/IngressEgressRuleConfigure.vue
+++ b/src/views/network/IngressEgressRuleConfigure.vue
@@ -80,8 +80,8 @@
       style="overflow-y: auto"
       :columns="columns"
       :dataSource="rules"
-      :pagination="false"
-      :rowKey="record => record.id">
+      :pagination="{ pageSizeOptions: ['10', '20', '40', '80', '100', '500'], showSizeChanger: true}"
+      :rowKey="record => record.ruleid">
       <template slot="protocol" slot-scope="record">
         {{ record.protocol | capitalise }}
       </template>
@@ -187,6 +187,8 @@ export default {
       tagsLoading: false,
       addType: 'cidr',
       tabType: null,
+      page: 1,
+      pagesize: 10,
       columns: [
         {
           title: this.$t('label.protocol'),


### PR DESCRIPTION
Fixes : 
- VR router offering link leads to an empty page
- In the event listview, clicking the username redirects to the event not the user
- While changing a systemvm service offering, need to fetch system offerings by passing issystem=true, virtualmachineid and systemvmtype to the listServiceOfferings api
- When editing a role, resource admin is not in the dropdown
- In DeployVM, disk offering search doesn't show 'No records' if none present but keeps the old rows
- In add ACL Rule, the Rule# field should be a number, not text
- No pagination for security groups ingress / egress rules