### PR TITLE
[FIX] VM Wizard - Remove oval animation on template/isos

### DIFF
--- a/src/views/compute/wizard/TemplateIsoRadioGroup.vue
+++ b/src/views/compute/wizard/TemplateIsoRadioGroup.vue
@@ -130,18 +130,10 @@ export default {
 
 <style lang="less" scoped>
   .radio-group {
-    display: block;
+    margin: 0.5rem 0;
 
     /deep/.ant-radio {
-      width: 35px;
-    }
-
-    &__radio {
-      margin: 0.5rem 0;
-
-      /deep/span:last-child {
-        display: inline-block;
-      }
+      margin-right: 20px;
     }
 
     &__os-logo {


### PR DESCRIPTION
Open for https://github.com/apache/cloudstack-primate/issues/520
Issues: On clicking the radio button we see an oval animation (minor issue, probably flex or CSS related)
- BEFORE:
![Screenshot_1](https://user-images.githubusercontent.com/13766648/87373684-550e3100-c5b4-11ea-824d-af9853263634.png)
- AFTER:
![image](https://user-images.githubusercontent.com/13766648/87373672-52134080-c5b4-11ea-8dee-10033b7a534e.png)