### PR TITLE
Fixing rootdisk size override

### DIFF
--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -960,7 +960,8 @@ export default {
         })
         const templates = this.options.templates.filter(x => x.id === value)
         if (templates.length > 0) {
-          this.dataPreFill.minrootdisksize = templates[0].size / (1024 * 1024 * 1024) || 0 // bytes to GB
+          var size = templates[0].size / (1024 * 1024 * 1024) || 0 // bytes to GB
+          this.dataPreFill.minrootdisksize = Math.ceil(size)
         }
       } else if (name === 'isoid') {
         this.tabKey = 'isoid'
@@ -1065,7 +1066,7 @@ export default {
         } else {
           deployVmData.templateid = values.isoid
         }
-        if (values.rootdisksize && values.rootdisksize > 0) {
+        if (this.showRootDiskSizeChanger && values.rootdisksize && values.rootdisksize > 0) {
           deployVmData.rootdisksize = values.rootdisksize
         }
         if (values.hypervisor && values.hypervisor.length > 0) {

--- a/src/views/compute/wizard/DiskSizeSelection.vue
+++ b/src/views/compute/wizard/DiskSizeSelection.vue
@@ -53,8 +53,9 @@ export default {
   },
   watch: {
     minDiskSize (newItem) {
-      if (this.inputValue < newItem) {
+      if (newItem && newItem > 0) {
         this.inputValue = newItem
+        this.updateDiskSize(newItem)
       }
     }
   },


### PR DESCRIPTION
Fixes #520:
- The rootdisk option shouldn't be passed via API if the override is/was not selected, also the value must be a whole number (than floating point). By default in VMware where I tested this, it is breaking VM deployment using Primate.