### PR TITLE
Dont display "isolated network" section for SG enabled zone

### DIFF
--- a/src/views/network/CreateL2NetworkForm.vue
+++ b/src/views/network/CreateL2NetworkForm.vue
@@ -303,7 +303,7 @@ export default {
       api('listZones', params).then(json => {
         for (const i in json.listzonesresponse.zone) {
           const zone = json.listzonesresponse.zone[i]
-          if (zone.networktype === 'Advanced' && zone.securitygroupsenabled !== true) {
+          if (zone.networktype === 'Advanced') {
             this.zones.push(zone)
           }
         }

--- a/src/views/network/CreateNetwork.vue
+++ b/src/views/network/CreateNetwork.vue
@@ -99,7 +99,7 @@ export default {
           return true
         }
       }
-      return true
+      return false
     },
     handleRefresh () {
       this.fetchData()


### PR DESCRIPTION
In the "add network" form, dont display the form for
isolated network if its an advanced zone with security
group enabled.


Steps:

Create an advanced zone with security groups enabled.
Login to ui, navigate to networks section and click on "Add network"

This should show only L2 and guest network option

![Screenshot 2020-07-22 at 13 27 45](https://user-images.githubusercontent.com/10645273/88171149-22e97880-cc1f-11ea-89f3-6e2ab27bc98b.png)
