### PR TITLE
Refresh VPC list after creating new one

### DIFF
--- a/src/views/network/CreateVpc.vue
+++ b/src/views/network/CreateVpc.vue
@@ -220,6 +220,7 @@ export default {
               loadingMessage: `${title} ${this.$t('label.in.progress')}`,
               catchMessage: this.$t('error.fetching.async.job.result')
             })
+            this.$emit('refresh-data')
           }
         }).catch(error => {
           this.$notifyError(error)


### PR DESCRIPTION
Currently after creating a new VPC, the list
get refreshed. So refresh it after adding a
new vpc