### PR TITLE
Use displayname instead of name for vm snapshots

### DIFF
--- a/src/config/section/storage.js
+++ b/src/config/section/storage.js
@@ -315,8 +315,9 @@ export default {
       permission: ['listVMSnapshot'],
       resourceType: 'VMSnapshot',
       columns: () => {
-        var fields = ['name', 'state', 'type', 'current', 'parentName', 'created']
+        var fields = ['displayname', 'state', 'type', 'current', 'parentName', 'created']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
+          fields.push('domain')
           fields.push('account')
         }
         return fields

--- a/src/config/section/storage.js
+++ b/src/config/section/storage.js
@@ -315,7 +315,7 @@ export default {
       permission: ['listVMSnapshot'],
       resourceType: 'VMSnapshot',
       columns: () => {
-        var fields = ['displayname', 'state', 'type', 'current', 'parentName', 'created']
+        var fields = ['displayname', 'state', 'name', 'type', 'current', 'parentName', 'created']
         if (['Admin', 'DomainAdmin'].includes(store.getters.userInfo.roletype)) {
           fields.push('domain')
           fields.push('account')


### PR DESCRIPTION
Printing name for vm snpashots doesnt make much
sense as it displays vm internal name instead
of user entered name.

Also display the domain name


Before the fix

![Screenshot 2020-08-17 at 12 22 40](https://user-images.githubusercontent.com/10645273/90389141-4fab7700-e089-11ea-8dbc-b7cdb779748c.png)


After the fix

![Screenshot 2020-08-17 at 12 53 56](https://user-images.githubusercontent.com/10645273/90389155-55a15800-e089-11ea-80bc-646339a854e4.png)
