### PR TITLE
Allow renaming cluster, host, and storage

### DIFF
--- a/src/config/section/infra/clusters.js
+++ b/src/config/section/infra/clusters.js
@@ -60,6 +60,13 @@ export default {
     },
     {
       api: 'updateCluster',
+      icon: 'edit',
+      label: 'label.edit',
+      dataView: true,
+      args: ['clustername']
+    },
+    {
+      api: 'updateCluster',
       icon: 'play-circle',
       label: 'label.action.enable.cluster',
       message: 'message.action.enable.cluster',

--- a/src/config/section/infra/hosts.js
+++ b/src/config/section/infra/hosts.js
@@ -59,7 +59,7 @@ export default {
       icon: 'edit',
       label: 'label.edit',
       dataView: true,
-      args: ['hosttags', 'oscategoryid'],
+      args: ['name', 'hosttags', 'oscategoryid'],
       mapping: {
         oscategoryid: {
           api: 'listOsCategories'

--- a/src/config/section/infra/primaryStorages.js
+++ b/src/config/section/infra/primaryStorages.js
@@ -61,7 +61,7 @@ export default {
       icon: 'edit',
       label: 'label.edit',
       dataView: true,
-      args: ['tags', 'capacitybytes', 'capacityiops']
+      args: ['name', 'tags', 'capacitybytes', 'capacityiops']
     },
     {
       api: 'enableStorageMaintenance',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -549,7 +549,7 @@
 "label.cluster.name": "Cluster Name",
 "label.cluster.size": "Cluster size",
 "label.clusterid": "Cluster",
-"label.clustername": "Cluster",
+"label.clustername": "Cluster Name",
 "label.clusternamelabel": "Cluster Name",
 "label.clusters": "Clusters",
 "label.clustertype": "Cluster Type",


### PR DESCRIPTION
## Description

Current CloudStack master (4.15.0.0-SNAPSHOT) API commands `updateHost`, `updateCluster`, and `updateStoragePool` allow updating the respective resource name.

This PR adds support for such edit buttons on CloudStack primate.
CloudStack PR: https://github.com/apache/cloudstack/pull/4165

## Screenshots
Update Host name:
![image](https://user-images.githubusercontent.com/5025148/91004145-c4ab0f00-e5a9-11ea-8785-b7e0cc28f929.png)

Update Cluster name:
![image](https://user-images.githubusercontent.com/5025148/91003788-a264c180-e5a8-11ea-8953-1b74f69949bc.png)

Update Storage name:
![image](https://user-images.githubusercontent.com/5025148/91004252-08057d80-e5aa-11ea-902c-a6ec33825a73.png)
