### PR TITLE
Change Docker build base image to lts-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 
 # Build example: docker build -t apache/cloudstack-primate:latest .
 
-FROM node:lts-buster AS build
+FROM node:lts-stretch AS build
 
 MAINTAINER "Apache CloudStack" <dev@cloudstack.apache.org>
 LABEL Description="Apache CloudStack Primate; Modern role-base progressive UI for Apache CloudStack"


### PR DESCRIPTION
Fixes: #616

Podman on CentOS 8 seems to choke on lts-buster.
Both node:lts-stretch and node:lts-buster run Node 12, so there is no compatibility issue.

The change was tested on a Debian buster base system with the distribution's Docker version and on CentOS 8 with Podman.