### PR TITLE
Close modal once snapshot task initiated

### DIFF
--- a/src/views/storage/TakeSnapshot.vue
+++ b/src/views/storage/TakeSnapshot.vue
@@ -176,12 +176,12 @@ export default {
                   description: successDescription,
                   status: 'progress'
                 })
-                this.closeAction()
               },
               loadingMessage: `${title} ${this.$t('label.in.progress.for')} ${description}`,
               catchMessage: this.$t('error.fetching.async.job.result')
             })
           }
+          this.closeAction()
         }).catch(error => {
           this.$notifyError(error)
         })


### PR DESCRIPTION
The "Take Snapshot" modal remains open until the job completes. This fix closes the dialog box, once job is initiated