### PR TITLE
Enable tags for lb rules

### DIFF
--- a/src/views/network/LoadBalancing.vue
+++ b/src/views/network/LoadBalancing.vue
@@ -111,7 +111,7 @@
       <template slot="actions" slot-scope="record">
         <div class="actions">
           <a-button shape="circle" icon="edit" @click="() => openEditRuleModal(record)"></a-button>
-          <a-button :disabled="!('editLoadBalancerRule' in $store.getters.apis)" shape="circle" icon="tag" @click="() => openTagsModal(record.id)" />
+          <a-button :disabled="!('updateLoadBalancerRule' in $store.getters.apis)" shape="circle" icon="tag" @click="() => openTagsModal(record.id)" />
           <a-popconfirm
             :title="$t('label.delete') + '?'"
             @confirm="handleDeleteRule(record)"
@@ -170,7 +170,7 @@
 
       <div v-show="!tagsModalLoading" class="tags-container">
         <div class="tags" v-for="(tag, index) in tags" :key="index">
-          <a-tag :key="index" :closable="'deleteTag' in $store.getters.apis" :afterClose="() => handleDeleteTag(tag)">
+          <a-tag :key="index" :closable="'deleteTags' in $store.getters.apis" :afterClose="() => handleDeleteTag(tag)">
             {{ tag.key }} = {{ tag.value }}
           </a-tag>
         </div>


### PR DESCRIPTION
Fixes #679 

Use updateLoadBalancerRule instead editLoadBalancerRule

There is no editLoadBalancerRule api

After the fix, im able to see and add tags to lb rules

![Screenshot 2020-09-09 at 18 30 46](https://user-images.githubusercontent.com/10645273/92626936-f1aa3200-f2ca-11ea-8c15-a0ead66e844b.png)

![Screenshot 2020-09-09 at 18 30 55](https://user-images.githubusercontent.com/10645273/92626952-f5d64f80-f2ca-11ea-8e6b-640135cfcaa6.png)
