### PR TITLE
Display ACL name instead of ID

### DIFF
--- a/src/config/section/network.js
+++ b/src/config/section/network.js
@@ -30,7 +30,7 @@ export default {
       permission: ['listNetworks'],
       resourceType: 'Network',
       columns: ['name', 'state', 'type', 'cidr', 'ip6cidr', 'broadcasturi', 'account', 'zonename'],
-      details: ['name', 'id', 'description', 'type', 'traffictype', 'vpcid', 'vlan', 'broadcasturi', 'cidr', 'ip6cidr', 'netmask', 'gateway', 'ispersistent', 'restartrequired', 'reservediprange', 'redundantrouter', 'networkdomain', 'zonename', 'account', 'domain'],
+      details: ['name', 'id', 'description', 'type', 'traffictype', 'vpcid', 'vlan', 'broadcasturi', 'cidr', 'ip6cidr', 'netmask', 'gateway', 'aclname', 'ispersistent', 'restartrequired', 'reservediprange', 'redundantrouter', 'networkdomain', 'zonename', 'account', 'domain'],
       searchFilters: ['keyword', 'zoneid', 'domainid', 'account', 'tags'],
       related: [{
         name: 'vm',

--- a/src/views/network/VpcTiersTab.vue
+++ b/src/views/network/VpcTiersTab.vue
@@ -52,7 +52,7 @@
               </div>
               <div>
                 <router-link :to="{ path: '/acllist/' + network.aclid }">
-                  {{ network.aclid }}
+                  {{ network.aclname }}
                 </router-link>
               </div>
             </div>


### PR DESCRIPTION
Fixes #676 

In networks tab under vpc, display acl names instead of id's
Also display acl name in network details page


![Screenshot 2020-09-09 at 19 19 21](https://user-images.githubusercontent.com/10645273/92631420-9f204400-f2d1-11ea-8b00-d23fe096209b.png)
