### PR TITLE
Start VPC router by default

### DIFF
--- a/src/views/network/CreateVpc.vue
+++ b/src/views/network/CreateVpc.vue
@@ -113,7 +113,7 @@
               <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
             </a-tooltip>
           </span>
-          <a-switch v-decorator="['start']" />
+          <a-switch v-decorator="['start', {initialValue: true}]" defaultChecked />
         </a-form-item>
       </a-form>
       <div :span="24" class="action-button">


### PR DESCRIPTION
Fixes #673 

According to docs, the router will be started as soon as
vpc is created. If user doesn't want it to start then they
need to explicitly set it to false

![Screenshot 2020-09-09 at 19 53 49](https://user-images.githubusercontent.com/10645273/92635474-312a4b80-f2d6-11ea-947a-0a9581a7dd4d.png)
