### PR TITLE
FIX - L2 networks - there is nothing to clean-up or make redundant

### DIFF
--- a/src/config/section/network.js
+++ b/src/config/section/network.js
@@ -81,7 +81,8 @@ export default {
           icon: 'sync',
           label: 'label.restart.network',
           dataView: true,
-          args: ['cleanup', 'makeredundant']
+          args: ['cleanup', 'makeredundant'],
+          show: (record) => record.type !== 'L2'
         },
         {
           api: 'replaceNetworkACLList',


### PR DESCRIPTION
Fixes #674 
@rhtyd cc @svenvogel 
Hide restart network button for L2 network.