### PR TITLE
FIX - Creating VPN user - regular "user" role is offered to specify account/domain

### DIFF
--- a/src/config/section/network.js
+++ b/src/config/section/network.js
@@ -550,7 +550,13 @@ export default {
           icon: 'plus',
           label: 'label.add.vpn.user',
           listView: true,
-          args: ['username', 'password', 'domainid', 'account']
+          args: (record, store) => {
+            if (store.userInfo.roletype === 'User') {
+              return ['username', 'password']
+            }
+
+            return ['username', 'password', 'domainid', 'account']
+          }
         },
         {
           api: 'removeVpnUser',


### PR DESCRIPTION
Fixes #677 
@rhtyd cc @svenvogel 
VPN user: hide account/domain field by regular user.