### PR TITLE
Fix small typo in message

### DIFF
--- a/src/views/network/IpAddressesTab.vue
+++ b/src/views/network/IpAddressesTab.vue
@@ -272,7 +272,7 @@ export default {
           errorMethod: () => {
             this.fetchData()
           },
-          loadingMessage: `${this.$t('label.acquiring.ip')}} ${this.$t('label.for')} ${this.resource.name} ${this.$t('label.is.in.progress')}}`,
+          loadingMessage: `${this.$t('label.acquiring.ip')} ${this.$t('label.for')} ${this.resource.name} ${this.$t('label.is.in.progress')}`,
           catchMessage: this.$t('error.fetching.async.job.result')
         })
       }).catch(error => {


### PR DESCRIPTION
Remove extra `}` from the popup message