### PR TITLE
zone id appears wrong

### DIFF
--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -1590,7 +1590,7 @@ export default {
             if (this.$route.query.zoneid) {
               zoneid = this.$route.query.zoneid
             } else if (this.options.zones.length === 1) {
-              zoneid = 'this.options.zones[0].id'
+              zoneid = this.options.zones[0].id
             }
             if (zoneid) {
               this.form.getFieldDecorator(['zoneid'], { initialValue: zoneid })


### PR DESCRIPTION
Code shown instead of zone id when number of zones = 1 in deploy VM form
![image](https://user-images.githubusercontent.com/10495417/93207770-18f47980-f779-11ea-9f80-29d21da95c2a.png)
