### PR TITLE
Storage type defaults to shared even on setting to local

### DIFF
--- a/src/views/offering/AddComputeOffering.vue
+++ b/src/views/offering/AddComputeOffering.vue
@@ -933,7 +933,7 @@ export default {
           issystem: this.isSystem,
           name: values.name,
           displaytext: values.displaytext,
-          storagetype: values.storageType,
+          storagetype: values.storagetype,
           provisioningtype: values.provisioningtype,
           cachemode: values.cachemode,
           customized: values.offeringtype !== 'fixed',


### PR DESCRIPTION
By default, the following parameters are passed :
```
{"GET":{"scheme":"http","host":"10.10.3.155:8080","filename":"/client/api/","query":{"issystem":"false","name":"test2","displaytext":"test2","provisioningtype":"thin","cachemode":"none","customized":"false","offerha":"false","limitcpuuse":"false","cpunumber":"1","cpuspeed":"200","memory":"200","isvolatile":"false","command":"createServiceOffering","response":"json"},"remote":{"Address":"10.10.3.155:8080"}}}
```
storagetype seems to be missing

![image](https://user-images.githubusercontent.com/10495417/93984545-90419300-fda1-11ea-94db-8593fd9a3975.png)


After the fix:
```
{"GET":{"scheme":"http","host":"localhost:5050","filename":"/client/api/","query":{"issystem":"false","name":"test3","displaytext":"test3","storagetype":"local","provisioningtype":"thin","cachemode":"none","customized":"false","offerha":"false","limitcpuuse":"false","cpunumber":"2","cpuspeed":"200","memory":"2000","isvolatile":"false","command":"createServiceOffering","response":"json"},"remote":{"Address":"127.0.0.1:5050"}}}
```
![image](https://user-images.githubusercontent.com/10495417/93984501-828c0d80-fda1-11ea-9bfd-4c16a08ce4a8.png)
