### PR TITLE
network: fix create offering values

### DIFF
--- a/src/views/offering/AddNetworkOffering.vue
+++ b/src/views/offering/AddNetworkOffering.vue
@@ -894,13 +894,13 @@ export default {
         if ('egressdefaultpolicy' in values && values.egressdefaultpolicy !== 'allow') {
           params.egressdefaultpolicy = false
         }
-        if ('promiscuousmode' in values && values.promiscuousmode !== '') {
+        if (values.promiscuousmode) {
           params['details[0].promiscuousMode'] = values.promiscuousmode
         }
-        if ('macaddresschanges' in values && values.macaddresschanges !== '') {
+        if (values.macaddresschanges) {
           params['details[0].macaddresschanges'] = values.macaddresschanges
         }
-        if ('forgedtransmits' in values && values.forgedtransmits !== '') {
+        if (values.forgedtransmits) {
           params['details[0].forgedtransmits'] = values.forgedtransmits
         }
         if (values.ispublic !== true) {

--- a/src/views/offering/AddNetworkOffering.vue
+++ b/src/views/offering/AddNetworkOffering.vue
@@ -146,10 +146,10 @@
             <a-radio-button value="">
               {{ $t('label.none') }}
             </a-radio-button>
-            <a-radio-button value="accept">
+            <a-radio-button value="true">
               {{ $t('label.accept') }}
             </a-radio-button>
-            <a-radio-button value="reject">
+            <a-radio-button value="false">
               {{ $t('label.reject') }}
             </a-radio-button>
           </a-radio-group>
@@ -164,10 +164,10 @@
             <a-radio-button value="">
               {{ $t('label.none') }}
             </a-radio-button>
-            <a-radio-button value="accept">
+            <a-radio-button value="true">
               {{ $t('label.accept') }}
             </a-radio-button>
-            <a-radio-button value="reject">
+            <a-radio-button value="false">
               {{ $t('label.reject') }}
             </a-radio-button>
           </a-radio-group>
@@ -182,10 +182,10 @@
             <a-radio-button value="">
               {{ $t('label.none') }}
             </a-radio-button>
-            <a-radio-button value="accept">
+            <a-radio-button value="true">
               {{ $t('label.accept') }}
             </a-radio-button>
-            <a-radio-button value="reject">
+            <a-radio-button value="false">
               {{ $t('label.reject') }}
             </a-radio-button>
           </a-radio-group>
@@ -894,13 +894,13 @@ export default {
         if ('egressdefaultpolicy' in values && values.egressdefaultpolicy !== 'allow') {
           params.egressdefaultpolicy = false
         }
-        if ('promiscuousmode' in values) {
+        if ('promiscuousmode' in values && values.promiscuousmode !== '') {
           params['details[0].promiscuousMode'] = values.promiscuousmode
         }
-        if ('macaddresschanges' in values) {
+        if ('macaddresschanges' in values && values.macaddresschanges !== '') {
           params['details[0].macaddresschanges'] = values.macaddresschanges
         }
-        if ('forgedtransmits' in values) {
+        if ('forgedtransmits' in values && values.forgedtransmits !== '') {
           params['details[0].forgedtransmits'] = values.forgedtransmits
         }
         if (values.ispublic !== true) {


### PR DESCRIPTION
Fixes #757 

createNetworkOffering API should have values for keys - `promiscuousmode`, `macaddresschanges`, `forgedtransmits` of `details` param as `true` or `false`