### PR TITLE
Load balancing and Port forwarding are not displayed properly

### DIFF
--- a/src/components/view/ResourceView.vue
+++ b/src/components/view/ResourceView.vue
@@ -120,8 +120,17 @@ export default {
         if (this.resource && this.resource.virtualmachineid && this.resource.vpcid) {
           return false
         }
-        if (this.resource && this.resource.vpcid && tab.name !== 'firewall') {
+        // dont display any option for source NAT IP of VPC
+        if (this.resource && this.resource.vpcid && !this.resource.issourcenat && tab.name !== 'firewall') {
           return true
+        }
+        // display LB and PF options for isolated networks if static nat is disabled
+        if (this.resource && !this.resource.vpcid) {
+          if (!this.resource.isstaticnat) {
+            return true
+          } else if (tab.name === 'firewall') {
+            return true
+          }
         }
         return this.networkService && this.networkService.service &&
           tab.networkServiceFilter(this.networkService.service)

--- a/src/views/network/PublicIpResource.vue
+++ b/src/views/network/PublicIpResource.vue
@@ -99,13 +99,18 @@ export default {
       this.loading = true
       this.portFWRuleCount = await this.fetchPortFWRule()
 
-      if (this.portFWRuleCount > 0) {
+      // disable load balancing rules only if port forwarding is enabled and
+      // network belongs to VPC
+      if (this.portFWRuleCount > 0 && this.resource.vpcid) {
         this.tabs = this.$route.meta.tabs.filter(tab => tab.name !== 'loadbalancing')
       } else {
         this.loadBalancerRuleCount = await this.fetchLoadBalancerRule()
 
+        // for isolated networks, display both LB and PF
+        // for VPC they are mutually exclusive
         if (this.loadBalancerRuleCount > 0) {
-          this.tabs = this.$route.meta.tabs.filter(tab => tab.name !== 'portforwarding')
+          this.tabs =
+            this.resource.vpcid ? this.$route.meta.tabs.filter(tab => tab.name !== 'portforwarding') : this.$route.meta.tabs
           this.loading = false
         } else {
           this.tabs = this.$route.meta.tabs


### PR DESCRIPTION
Fixes #766 

For isolated networks, load balancing, port forwarding and firewall
options are not displayed.
For source nat ip of vpc, all options are displayed but it should not be

Below are the expected actions according to legacy UI

for isolated networks

if static nat is disabled then display all options
if static nat is enabled then display only firewall tab


for VPC networks

for source nat IP, dont display any option
for other ip's firewall is always disabled.
Load balancing and port forwarding options are mutually exclusive