### PR TITLE
Add rootdisk size on compute offering

### DIFF
--- a/src/views/offering/AddComputeOffering.vue
+++ b/src/views/offering/AddComputeOffering.vue
@@ -333,28 +333,28 @@
             }]"
             :placeholder="this.$t('label.networkrate')"/>
         </a-form-item>
-          <a-form-item>
-            <span slot="label">
-              {{ $t('label.root.disk.size') }}
-              <a-tooltip :title="apiParams.provisioningtype.description">
-                <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
-              </a-tooltip>
-            </span>
-            <a-input
-              v-decorator="['rootdisksize', {
-                rules: [
-                  {
-                    validator: (rule, value, callback) => {
-                      if (value && (isNaN(value) || value <= 0)) {
-                        callback(this.$t('message.error.number'))
-                      }
-                      callback()
+        <a-form-item v-if="apiParams.rootdisksize">
+          <span slot="label">
+            {{ $t('label.root.disk.size') }}
+            <a-tooltip :title="apiParams.rootdisksize.description">
+              <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
+            </a-tooltip>
+          </span>
+          <a-input
+            v-decorator="['rootdisksize', {
+              rules: [
+                {
+                  validator: (rule, value, callback) => {
+                    if (value && (isNaN(value) || value <= 0)) {
+                      callback(this.$t('message.error.number'))
                     }
+                    callback()
                   }
-                ]
-              }]"
-              :placeholder="this.$t('label.root.disk.size')"/>
-          </a-form-item>
+                }
+              ]
+            }]"
+            :placeholder="this.$t('label.root.disk.size')"/>
+        </a-form-item>
         <a-form-item :label="$t('label.qostype')">
           <a-radio-group
             v-decorator="['qostype', {

--- a/src/views/offering/AddComputeOffering.vue
+++ b/src/views/offering/AddComputeOffering.vue
@@ -333,6 +333,28 @@
             }]"
             :placeholder="this.$t('label.networkrate')"/>
         </a-form-item>
+          <a-form-item>
+            <span slot="label">
+              {{ $t('label.root.disk.size') }}
+              <a-tooltip :title="apiParams.provisioningtype.description">
+                <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
+              </a-tooltip>
+            </span>
+            <a-input
+              v-decorator="['rootdisksize', {
+                rules: [
+                  {
+                    validator: (rule, value, callback) => {
+                      if (value && (isNaN(value) || value <= 0)) {
+                        callback(this.$t('message.error.number'))
+                      }
+                      callback()
+                    }
+                  }
+                ]
+              }]"
+              :placeholder="this.$t('label.root.disk.size')"/>
+          </a-form-item>
         <a-form-item :label="$t('label.qostype')">
           <a-radio-group
             v-decorator="['qostype', {
@@ -963,6 +985,9 @@ export default {
 
         if (values.networkrate != null && values.networkrate.length > 0) {
           params.networkrate = values.networkrate
+        }
+        if (values.rootdisksize != null && values.rootdisksize.length > 0) {
+          params.rootdisksize = values.rootdisksize
         }
         if (values.qostype === 'storage') {
           var customIops = values.iscustomizeddiskiops === true


### PR DESCRIPTION
## Description

This PR allows configuring a Service Offering with root disk size.
PR [Allow to configure root disk size via Service Offering (disk offering of type Service). #4341](https://github.com/apache/cloudstack/pull/4341) allows enforcing VM Root disk size accordingly to its Service Offering.

#### NOTE: Once PR https://github.com/apache/cloudstack/pull/4341 gets merged, the code of this PR will "work" with the new parameter at the API

## How Has This Been Tested?

- Create Service offering via UI with rootdisk (CloudStack from commit https://github.com/apache/cloudstack/pull/4341/commits/4f501f0624a44fe2414835f17f210bf977f08846)
- Assert that the offering has indeed the root disk size configured (same test as in https://github.com/apache/cloudstack/pull/4341)

## Screenshots:

1. **Empty:**
![image](https://user-images.githubusercontent.com/5025148/94621845-71eb0400-0287-11eb-93a8-1db52c66c1c8.png)

2. **Value not supported:**
![image](https://user-images.githubusercontent.com/5025148/94621923-8fb86900-0287-11eb-9a8b-de95ca919ade.png)

3. **Value for Root disk size supported:**
![image](https://user-images.githubusercontent.com/5025148/94618083-f9814480-0280-11eb-97e9-216144df60b2.png)