### PR TITLE
Fix visibility of action buttons for Isos and templates

### DIFF
--- a/src/views/image/IsoZones.vue
+++ b/src/views/image/IsoZones.vue
@@ -32,7 +32,7 @@
       <template slot="action" slot-scope="text, record">
         <span style="margin-right: 5px">
           <a-button
-            :disabled="!('copyIso' in $store.getters.apis)"
+            :disabled="!('copyIso' in $store.getters.apis && record.isready)"
             icon="copy"
             shape="circle"
             :loading="copyLoading"
@@ -40,7 +40,7 @@
         </span>
         <span style="margin-right: 5px">
           <a-popconfirm
-            v-if="'deleteIso' in $store.getters.apis"
+            v-if="'deleteIso' in $store.getters.apis && record.isready"
             placement="topRight"
             :title="$t('message.action.delete.iso')"
             :ok-text="$t('label.yes')"

--- a/src/views/image/TemplateZones.vue
+++ b/src/views/image/TemplateZones.vue
@@ -32,7 +32,7 @@
       <template slot="action" slot-scope="text, record">
         <span style="margin-right: 5px">
           <a-button
-            :disabled="!('copyTemplate' in $store.getters.apis)"
+            :disabled="!('copyTemplate' in $store.getters.apis && record.isready)"
             icon="copy"
             shape="circle"
             :loading="copyLoading"
@@ -40,7 +40,7 @@
         </span>
         <span style="margin-right: 5px">
           <a-button
-            :disabled="!('deleteTemplate' in $store.getters.apis)"
+            :disabled="!('deleteTemplate' in $store.getters.apis && record.isready)"
             type="danger"
             icon="delete"
             shape="circle"


### PR DESCRIPTION
Despite the template / iso being in 'Ready' state i.e., downloaded, the action buttons (copy and delete) don't appear even in refresh
![image](https://user-images.githubusercontent.com/10495417/94687970-98be3e80-034a-11eb-8d8c-53efa533dffe.png)

After fix:
![image](https://user-images.githubusercontent.com/10495417/94688009-a4aa0080-034a-11eb-87b1-274cc530ad37.png)

![image](https://user-images.githubusercontent.com/10495417/94688149-d15e1800-034a-11eb-8787-18f4ce2cb4cd.png)
