### PR TITLE
Fix dedicate zone to a domain / account

### DIFF
--- a/src/views/infra/zone/ZoneWizardLaunchZone.vue
+++ b/src/views/infra/zone/ZoneWizardLaunchZone.vue
@@ -355,7 +355,7 @@ export default {
 
       const params = {}
       params.zoneid = this.stepData.zoneReturned.id
-      params.domain = this.prefillContent.domainId ? this.prefillContent.domainId.value : null
+      params.domainid = this.prefillContent.domainId ? this.prefillContent.domainId.value : null
       params.account = this.prefillContent.account ? this.prefillContent.account.value : null
 
       try {


### PR DESCRIPTION
Fixes zone dedication

When a zone is attempted to be dedicated to a domain, it fails with the following error:
` Unable to execute API command dedicatezone due to missing parameter domainid`

![image](https://user-images.githubusercontent.com/10495417/94689015-f56e2900-034b-11eb-8a34-849b5c81e496.png)

