### PR TITLE
Provide support for adding tags for templates/iso

### DIFF
--- a/src/config/section/image.js
+++ b/src/config/section/image.js
@@ -43,7 +43,7 @@ export default {
         }
         return fields
       },
-      details: ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled', 'directdownload', 'deployasis', 'isextractable', 'isdynamicallyscalable', 'ispublic', 'isfeatured', 'crosszones', 'type', 'account', 'domain', 'created', 'url'],
+      details: ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled', 'directdownload', 'deployasis', 'isextractable', 'isdynamicallyscalable', 'ispublic', 'isfeatured', 'crosszones', 'type', 'templatetag', 'account', 'domain', 'created', 'url'],
       searchFilters: ['name', 'zoneid', 'tags'],
       related: [{
         name: 'vm',
@@ -94,7 +94,7 @@ export default {
           args: (record, store) => {
             var fields = ['name', 'displaytext', 'passwordenabled', 'ostypeid', 'isdynamicallyscalable']
             if (['Admin'].includes(store.userInfo.roletype)) {
-              fields.push('isrouting')
+              fields.push('isrouting', 'templatetag')
             }
             return fields
           }
@@ -179,7 +179,7 @@ export default {
         }
         return fields
       },
-      details: ['name', 'id', 'displaytext', 'checksum', 'ostypename', 'size', 'bootable', 'isready', 'directdownload', 'isextractable', 'ispublic', 'isfeatured', 'crosszones', 'account', 'domain', 'created'],
+      details: ['name', 'id', 'displaytext', 'checksum', 'ostypename', 'size', 'bootable', 'isready', 'directdownload', 'isextractable', 'ispublic', 'isfeatured', 'crosszones', 'templatetag', 'account', 'domain', 'created'],
       searchFilters: ['name', 'zoneid', 'tags'],
       related: [{
         name: 'vm',
@@ -224,7 +224,13 @@ export default {
               !(record.account === 'system' && record.domainid === 1) &&
               record.isready
           },
-          args: ['name', 'displaytext', 'bootable', 'ostypeid']
+          args: (record, store) => {
+            var fields = ['name', 'displaytext', 'bootable', 'ostypeid']
+            if (['Admin'].includes(store.userInfo.roletype)) {
+              fields.push('templatetag')
+            }
+            return fields
+          }
         },
         {
           api: 'updateIsoPermissions',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2076,6 +2076,7 @@
 "label.templatenames": "Template",
 "label.templates": "Templates",
 "label.templatesubject": "Subject",
+"label.templatetag": "Template Tag",
 "label.templatetotal": "Template",
 "label.templatetype": "Email Template",
 "label.tftp.dir": "TFTP Directory",

--- a/src/views/AutogenView.vue
+++ b/src/views/AutogenView.vue
@@ -946,6 +946,9 @@ export default {
               if (param.type === 'boolean') {
                 params[key] = false
               }
+              if (param.name === 'templatetag') {
+                params[key] = ''
+              }
               break
             }
             if (action.mapping && key in action.mapping && action.mapping[key].options) {

--- a/src/views/image/RegisterOrUploadIso.vue
+++ b/src/views/image/RegisterOrUploadIso.vue
@@ -147,6 +147,14 @@
             }]" />
         </a-form-item>
 
+        <a-form-item :label="$t('label.templatetag')" v-if="$store.getters.userInfo.roletype === 'Admin'">
+          <a-input
+            v-decorator="['templatetag', {
+              rules: [{ required: false }]
+            }]"
+            :placeholder="apiParams.templatetag.description" />
+        </a-form-item>
+
         <div :span="24" class="action-button">
           <a-button @click="closeAction">{{ this.$t('label.cancel') }}</a-button>
           <a-button :loading="loading" type="primary" @click="handleSubmit">{{ this.$t('label.ok') }}</a-button>

--- a/src/views/image/RegisterOrUploadTemplate.vue
+++ b/src/views/image/RegisterOrUploadTemplate.vue
@@ -369,6 +369,15 @@
             </a-form-item>
           </a-col>
         </a-row>
+        <a-row :gutter="12" v-if="$store.getters.userInfo.roletype === 'Admin'">
+          <a-form-item :label="$t('label.templatetag')">
+            <a-input
+              v-decorator="['templatetag', {
+                rules: [{ required: false }]
+              }]"
+              :placeholder="apiParams.templatetag.description" />
+          </a-form-item>
+        </a-row>
 
         <div :span="24" class="action-button">
           <a-button @click="closeAction">{{ this.$t('label.cancel') }}</a-button>


### PR DESCRIPTION
**Note: The support for backend is in https://github.com/apache/cloudstack/pull/4362. Once the backend pr is merged, this can be tested/merged as well**

The backed already supports having tags on the template and ISO
but we don't have support to add it from UI
This adds the support for adding tags while registering
template/iso or as well as updating already registered
template/iso with new tags.



Registering template/ISO


![Screenshot 2020-09-30 at 17 42 22](https://user-images.githubusercontent.com/10645273/94707928-4d089680-0344-11eb-9efc-14a5c29fc661.png)




Updating template/iso with new tags


![Screenshot 2020-09-30 at 17 43 04](https://user-images.githubusercontent.com/10645273/94708015-66a9de00-0344-11eb-8ee7-848aeb2c642f.png)




This is also displayed in the detail view


![Screenshot 2020-09-30 at 17 43 56](https://user-images.githubusercontent.com/10645273/94708113-85a87000-0344-11eb-860a-0f5078b3bdfc.png)
