### PR TITLE
vm: backend migration changes support

### DIFF
--- a/src/config/section/compute.js
+++ b/src/config/section/compute.js
@@ -311,6 +311,8 @@ export default {
           dataView: true,
           show: (record, store) => { return ['Stopped'].includes(record.state) && ['Admin'].includes(store.userInfo.roletype) },
           args: ['storageid', 'virtualmachineid'],
+          component: () => import('@/views/compute/MigrateVMStorage'),
+          popup: true,
           mapping: {
             storageid: {
               api: 'listStoragePools',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2911,6 +2911,7 @@
 "message.migrating.failed": "Migration failed",
 "message.migrating.processing": "Migration in progress for",
 "message.migrating.vm.to.host.failed": "Failed to migrate VM to host",
+"message.migrating.vm.to.storage.failed": "Failed to migrate VM to storage",
 "message.move.acl.order": "Move ACL rule order",
 "message.move.acl.order.failed": "Failed to move ACL rule",
 "message.move.acl.order.processing": "Moving ACL rule...",


### PR DESCRIPTION
Use `migrateVirtualMachineWithVolume` for stopped VM migration to a different storage pool