### PR TITLE
FIX - The multiple requests fetchData() when async job completed or execute callGroupApi

### DIFF
--- a/src/utils/plugins.js
+++ b/src/utils/plugins.js
@@ -66,7 +66,9 @@ export const pollJobPlugin = {
             key: jobId,
             duration: 2
           })
-          eventBus.$emit('async-job-complete', action)
+          if (!action || ('isFetchData' in action && action.isFetchData)) {
+            eventBus.$emit('async-job-complete')
+          }
           successMethod(result)
         } else if (result.jobstatus === 2) {
           message.error({
@@ -88,7 +90,9 @@ export const pollJobPlugin = {
             key: jobId,
             duration: 0
           })
-          eventBus.$emit('async-job-complete', action)
+          if (!action || ('isFetchData' in action && action.isFetchData)) {
+            eventBus.$emit('async-job-complete')
+          }
           errorMethod(result)
         } else if (result.jobstatus === 0) {
           if (showLoading) {

--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -1543,15 +1543,14 @@ export default {
                     duration: 0
                   })
                 }
-                eventBus.$emit('vm-refresh-data')
-              },
-              errorMethod: () => {
-                eventBus.$emit('vm-refresh-data')
               },
               loadingMessage: `${title} ${this.$t('label.in.progress')}`,
               catchMessage: this.$t('error.fetching.async.job.result'),
               catchMethod: () => {
                 eventBus.$emit('vm-refresh-data')
+              },
+              action: {
+                isFetchData: false
               }
             })
             this.$store.dispatch('AddAsyncJob', {

--- a/src/views/compute/DestroyVM.vue
+++ b/src/views/compute/DestroyVM.vue
@@ -143,7 +143,7 @@ export default {
               }
             },
             action: {
-              api: 'destroyVirtualMachine'
+              isFetchData: false
             }
           })
           this.closeAction()


### PR DESCRIPTION
@rhtyd @davidjumani cc @svenvogel 
I tested and found the error multiple requests when async job complete or execute callGroupApi from AutogenView.

1. Deploy VM

    - Before:
![Screenshot_1](https://user-images.githubusercontent.com/13766648/95283612-6c447e00-0886-11eb-9299-1cb5c76c36ca.png)
    - After:
![Screenshot_2](https://user-images.githubusercontent.com/13766648/95283623-72d2f580-0886-11eb-98a4-4820b99a47d1.png)

2. Destroy VM from list:

    - Before:
![Screenshot_3](https://user-images.githubusercontent.com/13766648/95283662-88481f80-0886-11eb-87fd-d5d2f8b014c2.png)
![Screenshot_4](https://user-images.githubusercontent.com/13766648/95283665-89794c80-0886-11eb-9768-09dd932594d3.png)
    - After:
![Screenshot_5](https://user-images.githubusercontent.com/13766648/95283688-94cc7800-0886-11eb-9945-9f754ef62270.png)
![Screenshot_6](https://user-images.githubusercontent.com/13766648/95283691-95fda500-0886-11eb-9224-c3fd341fcbdf.png)
