### PR TITLE
allow adding docker Private registry details while deploying cluster

### DIFF
--- a/src/components/view/ListView.vue
+++ b/src/components/view/ListView.vue
@@ -439,7 +439,9 @@ export default {
         value: this.editableValue
       }).then(json => {
         this.editableValueKey = null
-
+        if (record.name === 'cloud.kubernetes.cluster.experimental.features.enabled') {
+          this.$store.getters.features.kubernetesclusterexperimentalfeaturesenabled = this.editableValue
+        }
         this.$message.success(`${this.$t('message.setting.updated')} ${record.name}`)
         if (json.updateconfigurationresponse &&
           json.updateconfigurationresponse.configuration &&

--- a/src/components/view/ListView.vue
+++ b/src/components/view/ListView.vue
@@ -439,9 +439,7 @@ export default {
         value: this.editableValue
       }).then(json => {
         this.editableValueKey = null
-        if (record.name === 'cloud.kubernetes.cluster.experimental.features.enabled') {
-          this.$store.getters.features.kubernetesclusterexperimentalfeaturesenabled = this.editableValue
-        }
+        this.$store.dispatch('RefreshFeatures')
         this.$message.success(`${this.$t('message.setting.updated')} ${record.name}`)
         if (json.updateconfigurationresponse &&
           json.updateconfigurationresponse.configuration &&

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1603,7 +1603,7 @@
 "label.private.interface": "Private Interface",
 "label.private.ip.range": "Private IP Range",
 "label.private.ips": "Private IP Addresses",
-"label.private.registry": "Private registry",
+"label.private.registry": "Private Registry",
 "label.private.zone": "Private Zone",
 "label.privateinterface": "Private Interface",
 "label.privateip": "Private IP Address",

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -279,7 +279,7 @@ const user = {
       return new Promise((resolve, reject) => {
         api('listCapabilities').then(response => {
           const result = response.listcapabilitiesresponse.capability
-          resolve(reject)
+          resolve(result)
           commit('SET_FEATURES', result)
         }).catch(error => {
           reject(error)

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -274,6 +274,17 @@ const user = {
           reject(error)
         })
       })
+    },
+    RefreshFeatures ({ commit }) {
+      return new Promise((resolve, reject) => {
+        api('listCapabilities').then(response => {
+          const result = response.listcapabilitiesresponse.capability
+          resolve(reject)
+          commit('SET_FEATURES', result)
+        }).catch(error => {
+          reject(error)
+        })
+      })
     }
   }
 }

--- a/src/views/compute/CreateKubernetesCluster.vue
+++ b/src/views/compute/CreateKubernetesCluster.vue
@@ -176,11 +176,11 @@
           </span>
           <a-input
             v-decorator="['masternodes', {
-              initialValue: '1',
+              initialValue: '2',
               rules: [{ required: true, message: $t('message.error.input.value') },
                       {
                         validator: (rule, value, callback) => {
-                          if (value && (isNaN(value) || value <= 0)) {
+                          if (value && (isNaN(value) || value < 2)) {
                             callback(this.$t('message.validate.number'))
                           }
                           callback()
@@ -246,7 +246,7 @@
             </a-select-option>
           </a-select>
         </a-form-item>
-        <div v-if="$store.getters.features.kubernetesclusterexperimentalfeaturesenabled">
+        <div v-if="$store.getters.features.kubernetesclusterexperimentalfeaturesenabled === 'true'">
           <a-form-item :label="$t('label.private.registry')">
             <a-switch v-decorator="['privateregistry']" @change="checked => { this.usePrivateRegistry = checked }" />
           </a-form-item>
@@ -366,7 +366,6 @@ export default {
   },
   methods: {
     fetchData () {
-      console.log(this.$store.getters.features)
       this.fetchZoneData()
       this.fetchNetworkData()
       this.fetchKeyPairData()

--- a/src/views/compute/CreateKubernetesCluster.vue
+++ b/src/views/compute/CreateKubernetesCluster.vue
@@ -246,7 +246,65 @@
             </a-select-option>
           </a-select>
         </a-form-item>
-
+        <div v-if="$store.getters.features.kubernetesclusterexperimentalfeaturesenabled">
+          <a-form-item :label="$t('label.private.registry')">
+            <a-switch v-decorator="['privateregistry']" @change="checked => { this.usePrivateRegistry = checked }" />
+          </a-form-item>
+          <div v-if="usePrivateRegistry">
+            <a-form-item>
+              <span slot="label">
+                {{ $t('label.username') }}
+                <a-tooltip :title="apiParams.dockerregistryusername.description">
+                  <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
+                </a-tooltip>
+              </span>
+              <a-input
+                v-decorator="['dockerregistryusername', {
+                  rules: [{ required: true, message: $t('label.required') }]
+                }]"
+                :placeholder="apiParams.dockerregistryusername.description"/>
+            </a-form-item>
+            <a-form-item>
+              <span slot="label">
+                {{ $t('label.password') }}
+                <a-tooltip :title="apiParams.dockerregistrypassword.description">
+                  <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
+                </a-tooltip>
+              </span>
+              <a-input-password
+                v-decorator="['dockerregistrypassword', {
+                  rules: [{ required: true, message: $t('label.required') }]
+                }]"
+                :placeholder="apiParams.dockerregistrypassword.description"/>
+            </a-form-item>
+            <a-form-item>
+              <span slot="label">
+                {{ $t('label.url') }}
+                <a-tooltip :title="apiParams.dockerregistryurl.description">
+                  <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
+                </a-tooltip>
+              </span>
+              <a-input
+                v-decorator="['dockerregistryurl', {
+                  rules: [{ required: true, message: $t('label.required') }]
+                }]"
+                :placeholder="apiParams.dockerregistryurl.description"/>
+            </a-form-item>
+            <a-form-item>
+              <span slot="label">
+                {{ $t('label.email') }}
+                <a-tooltip :title="apiParams.dockerregistryemail.description">
+                  <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
+                </a-tooltip>
+              </span>
+              <a-input
+                v-decorator="['dockerregistryemail', {
+                  rules: [{ required: true, message: $t('label.required') }]
+                }]"
+                :placeholder="apiParams.dockerregistryemail.description"/>
+            </a-form-item>
+          </div>
+        </div>
         <div :span="24" class="action-button">
           <a-button @click="closeAction">{{ this.$t('label.cancel') }}</a-button>
           <a-button :loading="loading" type="primary" @click="handleSubmit">{{ this.$t('label.ok') }}</a-button>
@@ -277,6 +335,7 @@ export default {
       keyPairs: [],
       keyPairLoading: false,
       haEnabled: false,
+      usePrivateRegistry: false,
       loading: false
     }
   },
@@ -307,6 +366,7 @@ export default {
   },
   methods: {
     fetchData () {
+      console.log(this.$store.getters.features)
       this.fetchZoneData()
       this.fetchNetworkData()
       this.fetchKeyPairData()
@@ -468,6 +528,13 @@ export default {
         if (this.isValidValueForKey(values, 'keypair') && this.arrayHasItems(this.keyPairs) && this.keyPairs[values.keypair].id != null) {
           params.keypair = this.keyPairs[values.keypair].id
         }
+        if (this.usePrivateRegistry) {
+          params.dockerregistryusername = values.dockerregistryusername
+          params.dockerregistrypassword = values.dockerregistrypassword
+          params.dockerregistryurl = values.dockerregistryurl
+          params.dockerregistryemail = values.dockerregistryemail
+        }
+
         api('createKubernetesCluster', params).then(json => {
           const jobId = json.createkubernetesclusterresponse.jobid
           this.$store.dispatch('AddAsyncJob', {

--- a/src/views/compute/CreateKubernetesCluster.vue
+++ b/src/views/compute/CreateKubernetesCluster.vue
@@ -246,7 +246,7 @@
             </a-select-option>
           </a-select>
         </a-form-item>
-        <div v-if="$store.getters.features.kubernetesclusterexperimentalfeaturesenabled === 'true'">
+        <div v-if="$store.getters.features.kubernetesclusterexperimentalfeaturesenabled">
           <a-form-item :label="$t('label.private.registry')">
             <a-switch v-decorator="['privateregistry']" @change="checked => { this.usePrivateRegistry = checked }" />
           </a-form-item>


### PR DESCRIPTION
Addresses the following:
1. Allows users to add private registry - if experimental features flag is enabled
2. Sets min number of master nodes to 2 if HA is enabled

Added the Private registry flag:
![image](https://user-images.githubusercontent.com/10495417/95857415-35d09c80-0d79-11eb-9cb0-aba18dd338c5.png)

For HA, made the default value of number of master nodes to 2:
Default initial value:
![image](https://user-images.githubusercontent.com/10495417/95857498-54cf2e80-0d79-11eb-8fba-0b033a39e6c3.png)

Setting it to a value lesser than 2 (which ideally isn't HA), will prompt the user:
![image](https://user-images.githubusercontent.com/10495417/95857568-70d2d000-0d79-11eb-938c-388e18364732.png)
