### PR TITLE
Hiding boot mode and boot type for VMware

### DIFF
--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -473,7 +473,7 @@
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div
-                      v-if="vm.templateid && ['KVM', 'VMware'].includes(hypervisor)">
+                      v-if="vm.templateid && ['KVM', 'VMware'].includes(hypervisor) && !template.deployasis">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
                           v-decorator="['boottype']"

--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -469,7 +469,7 @@
                 <template slot="description" v-if="zoneSelected">
                   <span>
                     {{ $t('label.isadvanced') }}
-                    <a-switch @change="val => { this.showDetails = val }" style="margin-left: 10px"/>
+                    <a-switch @change="val => { this.showDetails = val }" :checked="this.showDetails" style="margin-left: 10px"/>
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div

--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -473,7 +473,7 @@
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div
-                      v-if="vm.templateid && ['KVM', 'VMware'].includes(hypervisor)">
+                      v-if="vm.templateid && ['KVM'].includes(hypervisor)">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
                           v-decorator="['boottype']"

--- a/src/views/compute/DeployVM.vue
+++ b/src/views/compute/DeployVM.vue
@@ -473,7 +473,7 @@
                   </span>
                   <div style="margin-top: 15px" v-show="this.showDetails">
                     <div
-                      v-if="vm.templateid && ['KVM'].includes(hypervisor)">
+                      v-if="vm.templateid && ['KVM', 'VMware'].includes(hypervisor)">
                       <a-form-item :label="$t('label.boottype')">
                         <a-select
                           v-decorator="['boottype']"

--- a/src/views/image/RegisterOrUploadTemplate.vue
+++ b/src/views/image/RegisterOrUploadTemplate.vue
@@ -774,9 +774,6 @@ export default {
           return
         }
         let params = {}
-        if (this.hyperVMWShow) {
-          params.ostypeid = this.defaultOsId
-        }
         for (const key in values) {
           const input = values[key]
 


### PR DESCRIPTION
VMware doesn't respect boot mode and type for templates, so hiding them

Added the backend fix : https://github.com/apache/cloudstack/pull/4410

![Screenshot from 2020-10-16 12-59-57](https://user-images.githubusercontent.com/8244774/96226246-ffc92d80-0faf-11eb-8be7-7e60a7badfac.png)
