### PR TITLE
infocard: Adding support to redirect to publicip

### DIFF
--- a/src/components/view/InfoCard.vue
+++ b/src/components/view/InfoCard.vue
@@ -308,7 +308,8 @@
               type="environment"
               @click="$message.success(`${$t('label.copied.clipboard')} : ${ ipaddress }`)"
               v-clipboard:copy="ipaddress" />
-            <span>{{ ipaddress }}</span>
+            <router-link v-if="resource.ipaddressid" :to="{ path: '/publicip/' + resource.ipaddressid }">{{ ipaddress }}</router-link>
+            <span v-else>{{ ipaddress }}</span>
           </div>
         </div>
         <div class="resource-detail-item" v-if="resource.projectid || resource.projectname">


### PR DESCRIPTION
Adding support to redirect to publicip. Works with cks clusters after https://github.com/apache/cloudstack/pull/4414

![Screenshot from 2020-10-20 17-56-40](https://user-images.githubusercontent.com/8244774/96585811-b5bcb080-12fd-11eb-9ef5-6f52e8d1c289.png)
