### PR TITLE
Fix - Incorrect results of list view when refreshing browser

### DIFF
--- a/src/views/AutogenView.vue
+++ b/src/views/AutogenView.vue
@@ -505,6 +505,12 @@ export default {
         params.isofilter = 'all'
       }
       if (Object.keys(this.$route.query).length > 0) {
+        if ('page' in this.$route.query) {
+          this.page = Number(this.$route.query.page)
+        }
+        if ('pagesize' in this.$route.query) {
+          this.pagesize = Number(this.$route.query.pagesize)
+        }
         Object.assign(params, this.$route.query)
       }
       delete params.q


### PR DESCRIPTION
@rhtyd cc @svenvogel 
When URL has query params (page, page size) and if I refresh the browser then listview result will incorrect
![image](https://user-images.githubusercontent.com/13766648/96682768-7cd71700-13a3-11eb-8d7c-5d7d5e8fbb6f.png)
![image](https://user-images.githubusercontent.com/13766648/96682816-8a8c9c80-13a3-11eb-9b1d-6435b6430763.png)
