### PR TITLE
Display day name instead of label

### DIFF
--- a/src/views/storage/FormSchedule.vue
+++ b/src/views/storage/FormSchedule.vue
@@ -258,7 +258,7 @@ export default {
         const dayName = this.listDayOfWeek[index]
         this.dayOfWeek.push({
           id: dayName,
-          name: 'label.' + this.$t(dayName)
+          name: this.$t('label.' + dayName)
         })
       }
     },


### PR DESCRIPTION
Fixes #833

Display day name instead of label
﻿
![Screenshot 2020-10-27 at 10 52 58](https://user-images.githubusercontent.com/10645273/97285504-957f7b00-1842-11eb-978f-82d7af39eb52.png)
