### PR TITLE
Allow changing template type by admin

### DIFF
--- a/src/config/section/image.js
+++ b/src/config/section/image.js
@@ -43,7 +43,15 @@ export default {
         }
         return fields
       },
-      details: ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled', 'directdownload', 'deployasis', 'isextractable', 'isdynamicallyscalable', 'ispublic', 'isfeatured', 'crosszones', 'type', 'account', 'domain', 'created', 'url'],
+      details: () => {
+        var fields = ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled',
+          'directdownload', 'deployasis', 'isextractable', 'isdynamicallyscalable', 'crosszones', 'type',
+          'account', 'domain', 'created']
+        if (['Admin'].includes(store.getters.userInfo.roletype)) {
+          fields.push('ispublic', 'isrouting', 'isfeatured', 'templatetype', 'url')
+        }
+        return fields
+      },
       searchFilters: ['name', 'zoneid', 'tags'],
       related: [{
         name: 'vm',
@@ -94,9 +102,14 @@ export default {
           args: (record, store) => {
             var fields = ['name', 'displaytext', 'passwordenabled', 'ostypeid', 'isdynamicallyscalable']
             if (['Admin'].includes(store.userInfo.roletype)) {
-              fields.push('isrouting')
+              fields.push('isrouting', 'templatetype')
             }
             return fields
+          },
+          mapping: {
+            templatetype: {
+              options: ['BUILTIN', 'USER', 'SYSTEM', 'ROUTING', 'PERHOST']
+            }
           }
         },
         {

--- a/src/config/section/image.js
+++ b/src/config/section/image.js
@@ -45,10 +45,10 @@ export default {
       },
       details: () => {
         var fields = ['name', 'id', 'displaytext', 'checksum', 'hypervisor', 'format', 'ostypename', 'size', 'isready', 'passwordenabled',
-          'directdownload', 'deployasis', 'isextractable', 'isdynamicallyscalable', 'crosszones', 'type',
+          'directdownload', 'deployasis', 'ispublic', 'isfeatured', 'isextractable', 'isdynamicallyscalable', 'crosszones', 'type',
           'account', 'domain', 'created']
         if (['Admin'].includes(store.getters.userInfo.roletype)) {
-          fields.push('ispublic', 'isrouting', 'isfeatured', 'templatetype', 'url')
+          fields.push('templatetype', 'url')
         }
         return fields
       },

--- a/src/config/section/image.js
+++ b/src/config/section/image.js
@@ -108,7 +108,7 @@ export default {
           },
           mapping: {
             templatetype: {
-              options: ['BUILTIN', 'USER', 'SYSTEM', 'ROUTING', 'PERHOST']
+              options: ['BUILTIN', 'USER', 'SYSTEM', 'ROUTING']
             }
           }
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2079,7 +2079,7 @@
 "label.templates": "Templates",
 "label.templatesubject": "Subject",
 "label.templatetotal": "Template",
-"label.templatetype": "Email Template",
+"label.templatetype": "Template Type",
 "label.tftp.dir": "TFTP Directory",
 "label.tftpdir": "Tftp root directory",
 "label.theme.default": "Default Theme",


### PR DESCRIPTION
Fixes #835 

Currently, the template has the following types:
'BUILTIN', 'USER', 'SYSTEM', 'ROUTING'

Provide ui support for admins os that they can change
the template type

![Screenshot 2020-10-27 at 19 10 09](https://user-images.githubusercontent.com/10645273/97343646-0a28d880-1888-11eb-84f6-0f33c4ff5b9a.png)

Template type can be seen in template details also

![Screenshot 2020-10-27 at 19 10 28](https://user-images.githubusercontent.com/10645273/97343687-157c0400-1888-11eb-835a-f1f0395d66f7.png)
