### PR TITLE
showing ostypeid input even if we use vmware because cloudstack api requires it

### DIFF
--- a/src/views/image/RegisterOrUploadTemplate.vue
+++ b/src/views/image/RegisterOrUploadTemplate.vue
@@ -208,14 +208,14 @@
           </a-form-item>
         </a-row>
         <a-row :gutter="12" v-if="hyperKVMShow || hyperVMWShow">
-          <a-col :md="24" :lg="24" v-if="hyperKVMShow">
+          <a-col :md="24" :lg="24">
             <a-form-item :label="$t('label.rootdiskcontrollertype')">
               <a-select
                 v-decorator="['rootDiskControllerType', {
                   initialValue: rootDisk.opts.length > 0 ? 'osdefault' : '',
                   rules: [
                     {
-                      required: true,
+                      required: hyperKVMShow,
                       message: `${this.$t('message.error.select')}`
                     }
                   ]
@@ -247,7 +247,7 @@
             </a-form-item>
           </a-col>
         </a-row>
-        <a-row :gutter="12" v-if="!hyperVMWShow">
+        <a-row :gutter="12">
           <a-col :md="24" :lg="24">
             <a-form-item :label="$t('label.ostypeid')">
               <a-select


### PR DESCRIPTION
When trying to create a VMware template, OS is not selectable and so you get an error from cloudstack api. Based on the old UI, I think rootdiskcontrollertype should also be visible for vmware.

Old UI: https://prnt.sc/v8itpf
New UI: https://prnt.sc/v8iu6w