### PR TITLE
packaging: enforce new min. CloudStack version 4.15 starting GA/1.0

### DIFF
--- a/packaging/centos/primate.spec
+++ b/packaging/centos/primate.spec
@@ -34,7 +34,7 @@ Modern Apache CloudStack UI - Primate
 
 %package primate
 Summary:   Modern Apache CloudStack UI - Primate
-Requires:  cloudstack-management >= 4.13.0
+Requires:  cloudstack-management >= 4.15.0
 Group:     System Environment/Libraries
 %description primate
 Primate - modern role-base progressive UI for Apache CloudStack

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,6 +8,6 @@ Homepage: https://cloudstack.apache.org/
 
 Package: cloudstack-primate
 Architecture: all
-Depends: cloudstack-management (>= 4.13.0)
+Depends: cloudstack-management (>= 4.15.0)
 Description: CloudStack Primate
  The modern CloudStack UI - Primate


### PR DESCRIPTION
There are many changes, including API changes in upstream master/4.15
which makes it challenging to maintain backward compability of Primate
with older versions of CloudStack. Therefore we need to ensure that the
rpm and deb Primate pkgs require CloudStack 4.15 as minimum version.
This would still leave some flexibility for advanced users of archive
builds (which adds risks that some features don't work with 4.14 or
older versions).
