### PR TITLE
Show display text instead of name

### DIFF
--- a/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/src/views/network/CreateIsolatedNetworkForm.vue
@@ -125,7 +125,7 @@
               :placeholder="this.$t('label.networkofferingid')"
               @change="val => { this.handleNetworkOfferingChange(this.networkOfferings[val]) }">
               <a-select-option v-for="(opt, optIndex) in this.networkOfferings" :key="optIndex">
-                {{ opt.name || opt.description }}
+                {{ opt.displaytext || opt.description }}
               </a-select-option>
             </a-select>
           </a-form-item>

--- a/src/views/network/CreateL2NetworkForm.vue
+++ b/src/views/network/CreateL2NetworkForm.vue
@@ -125,7 +125,7 @@
               :placeholder="this.$t('label.networkofferingid')"
               @change="val => { this.handleNetworkOfferingChange(this.networkOfferings[val]) }">
               <a-select-option v-for="(opt, optIndex) in this.networkOfferings" :key="optIndex">
-                {{ opt.name || opt.description }}
+                {{ opt.displaytext || opt.description }}
               </a-select-option>
             </a-select>
           </a-form-item>

--- a/src/views/network/CreateSharedNetworkForm.vue
+++ b/src/views/network/CreateSharedNetworkForm.vue
@@ -284,7 +284,7 @@
               :placeholder="this.$t('label.networkofferingid')"
               @change="val => { this.handleNetworkOfferingChange(this.networkOfferings[val]) }">
               <a-select-option v-for="(opt, optIndex) in this.networkOfferings" :key="optIndex">
-                {{ opt.name || opt.description }}
+                {{ opt.displaytext || opt.description }}
               </a-select-option>
             </a-select>
           </a-form-item>


### PR DESCRIPTION
While creating networks, for network offerings, show meaningful display text
instead of short names which is not much descriptive


![Screenshot 2020-11-04 at 17 07 36](https://user-images.githubusercontent.com/10645273/98135558-3ebc1600-1ec0-11eb-9b56-c8b102fb7570.png)
