### PR TITLE
Display network type in network overview

### DIFF
--- a/src/config/section/network.js
+++ b/src/config/section/network.js
@@ -29,7 +29,16 @@ export default {
       icon: 'apartment',
       permission: ['listNetworks'],
       resourceType: 'Network',
-      columns: ['name', 'state', 'type', 'cidr', 'ip6cidr', 'broadcasturi', 'account', 'zonename'],
+      columns: ['name', 'state',
+        {
+          type: (record) => {
+            if (record.vpcid && record.vpcid !== '') {
+              return 'VPC Tier'
+            }
+            return record.type
+          }
+        },
+        'cidr', 'ip6cidr', 'broadcasturi', 'account', 'zonename'],
       details: ['name', 'id', 'description', 'type', 'traffictype', 'vpcid', 'vlan', 'broadcasturi', 'cidr', 'ip6cidr', 'netmask', 'gateway', 'aclname', 'ispersistent', 'restartrequired', 'reservediprange', 'redundantrouter', 'networkdomain', 'zonename', 'account', 'domain'],
       filters: ['all', 'isolated', 'shared', 'l2'],
       searchFilters: ['keyword', 'zoneid', 'domainid', 'account', 'tags'],

--- a/src/config/section/network.js
+++ b/src/config/section/network.js
@@ -29,16 +29,7 @@ export default {
       icon: 'apartment',
       permission: ['listNetworks'],
       resourceType: 'Network',
-      columns: ['name', 'state',
-        {
-          type: (record) => {
-            if (record.vpcid && record.vpcid !== '') {
-              return 'VPC Tier'
-            }
-            return record.type
-          }
-        },
-        'cidr', 'ip6cidr', 'broadcasturi', 'account', 'zonename'],
+      columns: ['name', 'state', 'type', 'vpcname', 'cidr', 'ip6cidr', 'broadcasturi', 'domain', 'account', 'zonename'],
       details: ['name', 'id', 'description', 'type', 'traffictype', 'vpcid', 'vlan', 'broadcasturi', 'cidr', 'ip6cidr', 'netmask', 'gateway', 'aclname', 'ispersistent', 'restartrequired', 'reservediprange', 'redundantrouter', 'networkdomain', 'zonename', 'account', 'domain'],
       filters: ['all', 'isolated', 'shared', 'l2'],
       searchFilters: ['keyword', 'zoneid', 'domainid', 'account', 'tags'],


### PR DESCRIPTION
Display "VPC Tier" as type if an isolated network belongs to VPC
else display its regular type

![Screenshot 2020-11-19 at 16 35 16](https://user-images.githubusercontent.com/10645273/99687668-3699d400-2a85-11eb-873d-a60414e69322.png)

**Backend changes are in https://github.com/apache/cloudstack/pull/4483**