### PR TITLE
Make internaldns1 optional while creating zone

### DIFF
--- a/src/views/infra/zone/ZoneWizardZoneDetailsStep.vue
+++ b/src/views/infra/zone/ZoneWizardZoneDetailsStep.vue
@@ -165,8 +165,6 @@
           v-decorator="['internalDns1', {
             rules: [
               {
-                required: true,
-                message: $t('message.error.internal.dns1'),
                 initialValue: internalDns1
               },
               {


### PR DESCRIPTION
Make the field optional so that we dont need to
enter it while creting zone if we dont have any
internal dns server

**NOTE: Backend change is in https://github.com/apache/cloudstack/pull/4448**