### PR TITLE
Enable delete icon on detached volumes

### DIFF
--- a/src/config/section/storage.js
+++ b/src/config/section/storage.js
@@ -226,7 +226,7 @@ export default {
           groupAction: true,
           show: (record, store) => {
             return ['Expunging', 'Expunged', 'UploadError'].includes(record.state) ||
-              ['Allocated', 'Uploaded'].includes(record.state) && record.type !== 'ROOT' && !record.virtualmachineid ||
+              ['Allocated', 'Uploaded', 'Ready'].includes(record.state) && record.type !== 'ROOT' && !record.virtualmachineid ||
               ((['Admin', 'DomainAdmin'].includes(store.userInfo.roletype) || store.features.allowuserexpungerecovervolume) && record.state === 'Destroy')
           }
         },


### PR DESCRIPTION
When you detach some volume, we cannot see the delete button
![image](https://user-images.githubusercontent.com/19981369/98957396-e8faf580-24df-11eb-84d1-aa230981e395.png)

This PR enable us to see this button on detached volumes
![image](https://user-images.githubusercontent.com/19981369/98957527-0b8d0e80-24e0-11eb-84a0-b1779b26d00a.png)
