### PR TITLE
Display IP address while deleting it

### DIFF
--- a/src/views/AutogenView.vue
+++ b/src/views/AutogenView.vue
@@ -992,7 +992,8 @@ export default {
           }
         }
 
-        const resourceName = params.displayname || params.displaytext || params.name || params.hostname || params.username || params.ipaddress || params.virtualmachinename || this.resource.name
+        const resourceName = params.displayname || params.displaytext || params.name || params.hostname || params.username ||
+          params.ipaddress || params.virtualmachinename || this.resource.name || this.resource.ipaddress
 
         var hasJobId = false
         this.actionLoading = true


### PR DESCRIPTION
While deleting an IP address, the status message displays "Undefined" instead of IP.

![Screenshot 2020-11-20 at 16 03 05](https://user-images.githubusercontent.com/10645273/99815324-6b239380-2b4a-11eb-93f4-71fb8b986456.png)


Navigate to Networks -> Public IP address -> Select any public ip -> Click delete button on top right


After the fix

![Screenshot 2020-11-20 at 16 04 31](https://user-images.githubusercontent.com/10645273/99815486-aa51e480-2b4a-11eb-9f70-f22412579e3d.png)
