### PR TITLE
List all suitable/available zones while creating networks

### DIFF
--- a/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/src/views/network/CreateIsolatedNetworkForm.vue
@@ -329,7 +329,7 @@ export default {
     fetchZoneData () {
       this.zones = []
       const params = {}
-      if (this.resource.zoneid) {
+      if (this.resource.zoneid && this.$route.name === 'deployVirtualMachine') {
         params.id = this.resource.zoneid
       }
       params.listAll = true

--- a/src/views/network/CreateL2NetworkForm.vue
+++ b/src/views/network/CreateL2NetworkForm.vue
@@ -304,7 +304,7 @@ export default {
     fetchZoneData () {
       this.zones = []
       const params = {}
-      if (this.resource.zoneid) {
+      if (this.resource.zoneid && this.$route.name === 'deployVirtualMachine') {
         params.id = this.resource.zoneid
       }
       params.listAll = true

--- a/src/views/network/CreateSharedNetworkForm.vue
+++ b/src/views/network/CreateSharedNetworkForm.vue
@@ -519,7 +519,7 @@ export default {
         }
       } else {
         const params = {}
-        if (this.resource.zoneid) {
+        if (this.resource.zoneid && this.$route.name === 'deployVirtualMachine') {
           params.id = this.resource.zoneid
         }
         params.listAll = true


### PR DESCRIPTION
Currently, network creation forms (shared,L2,isolated) only lists one zone:

L2:
![image](https://user-images.githubusercontent.com/10495417/100227838-cc32d900-2f47-11eb-8767-7af249345ada.png)

Shared:
![image](https://user-images.githubusercontent.com/10495417/100227867-d81e9b00-2f47-11eb-8a3e-8624a03af678.png)

Isolated:
![image](https://user-images.githubusercontent.com/10495417/100227893-e2d93000-2f47-11eb-8bb5-168ef88c3d70.png)


## Post Fix:

L2:
![image](https://user-images.githubusercontent.com/10495417/100227793-b3c2be80-2f47-11eb-91ec-e27473b454d6.png)

Shared:
![image](https://user-images.githubusercontent.com/10495417/100227924-f08eb580-2f47-11eb-8172-7dce5b38dd38.png)

Isolated:
![image](https://user-images.githubusercontent.com/10495417/100227952-f97f8700-2f47-11eb-8e37-681fa764df18.png)

However, from the deploy instance view - we still restrict the zone during network creation to the zone specified in the deployment wizard:
![image](https://user-images.githubusercontent.com/10495417/100227529-4c0c7380-2f47-11eb-93ec-33a74bd362c6.png)


