### PR TITLE
createsharednetworkform: Fix for multiple physical networks

### DIFF
--- a/src/views/network/CreateSharedNetworkForm.vue
+++ b/src/views/network/CreateSharedNetworkForm.vue
@@ -94,7 +94,7 @@
               }"
               :loading="zoneLoading"
               :placeholder="this.$t('label.physicalnetworkid')"
-              @change="val => { this.handleZoneChange(this.formPhysicalNetworks[val]) }">
+              @change="val => { this.handlePhysicalNetworkChange(this.formPhysicalNetworks[val]) }">
               <a-select-option v-for="(opt, optIndex) in this.formPhysicalNetworks" :key="optIndex">
                 {{ opt.name || opt.description }}
               </a-select-option>
@@ -638,7 +638,7 @@ export default {
         state: 'Enabled'
       }
       if (!this.isObjectEmpty(this.formSelectedPhysicalNetwork) &&
-        !this.isObjectEmpty(this.formSelectedPhysicalNetwork.tags) &&
+        this.formSelectedPhysicalNetwork.tags &&
         this.formSelectedPhysicalNetwork.tags.length > 0) {
         params.tags = this.formSelectedPhysicalNetwork.tags
       }
@@ -650,6 +650,8 @@ export default {
           params.domainid = this.selectedDomain.id
         }
       }
+      this.handleNetworkOfferingChange(null)
+      this.networkOfferings = []
       api('listNetworkOfferings', params).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering
       }).finally(() => {
@@ -659,6 +661,10 @@ export default {
             networkofferingid: 0
           })
           this.handleNetworkOfferingChange(this.networkOfferings[0])
+        } else {
+          this.form.setFieldsValue({
+            networkofferingid: null
+          })
         }
       })
     },


### PR DESCRIPTION
Fixing errors && fetching incorrect service offerings when there are multiple physical networks while trying to create a shared network