### PR TITLE
phynetworks: Adding tags and zonename to list & detail view

### DIFF
--- a/src/config/section/infra/phynetworks.js
+++ b/src/config/section/infra/phynetworks.js
@@ -22,8 +22,8 @@ export default {
   icon: 'api',
   hidden: true,
   permission: ['listPhysicalNetworks'],
-  columns: ['name', 'state', 'isolationmethods', 'vlan', 'broadcastdomainrange', 'zoneid'],
-  details: ['name', 'state', 'isolationmethods', 'vlan', 'broadcastdomainrange', 'zoneid'],
+  columns: ['name', 'state', 'isolationmethods', 'vlan', 'broadcastdomainrange', 'zonename', 'tags'],
+  details: ['name', 'state', 'isolationmethods', 'vlan', 'broadcastdomainrange', 'zonename', 'tags'],
   tabs: [{
     name: 'details',
     component: () => import('@/components/view/DetailsTab.vue')


### PR DESCRIPTION
Fixes https://github.com/apache/cloudstack-primate/issues/881
Also incorporates zone name instead of id while displaying physical networks https://github.com/apache/cloudstack/pull/4510

![Screenshot from 2020-12-01 23-58-51](https://user-images.githubusercontent.com/8244774/100782106-f0078a80-3431-11eb-8df3-2d9f4df5ae4b.png)
![Screenshot from 2020-12-01 23-59-00](https://user-images.githubusercontent.com/8244774/100782113-f138b780-3431-11eb-8b85-07081553e1dc.png)

