### PR TITLE
createnetworkform: Displaying api errors

### DIFF
--- a/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/src/views/network/CreateIsolatedNetworkForm.vue
@@ -415,6 +415,8 @@ export default {
       this.selectedNetworkOffering = {}
       api('listNetworkOfferings', params).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering
+      }).catch(error => {
+        this.$notifyError(error)
       }).finally(() => {
         this.networkOfferingLoading = false
         if (this.arrayHasItems(this.networkOfferings)) {

--- a/src/views/network/CreateL2NetworkForm.vue
+++ b/src/views/network/CreateL2NetworkForm.vue
@@ -387,6 +387,8 @@ export default {
       }
       api('listNetworkOfferings', params).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering
+      }).catch(error => {
+        this.$notifyError(error)
       }).finally(() => {
         this.networkOfferingLoading = false
         if (this.arrayHasItems(this.networkOfferings)) {

--- a/src/views/network/CreateSharedNetworkForm.vue
+++ b/src/views/network/CreateSharedNetworkForm.vue
@@ -654,6 +654,8 @@ export default {
       this.networkOfferings = []
       api('listNetworkOfferings', params).then(json => {
         this.networkOfferings = json.listnetworkofferingsresponse.networkoffering
+      }).catch(error => {
+        this.$notifyError(error)
       }).finally(() => {
         this.networkOfferingLoading = false
         if (this.arrayHasItems(this.networkOfferings)) {


### PR DESCRIPTION
Shows errors while fetching network offerings. Especially noticeable when there are multiple guest physical networks in a zone but are untagged.
Makes life easier for the user so he knows what's wrong rather than just shown empty dropdowns

![Screenshot from 2020-12-03 12-46-32](https://user-images.githubusercontent.com/8244774/100976495-9b652c00-3565-11eb-8c7b-f14c0a794366.png)

![Screenshot from 2020-12-02 15-04-49](https://user-images.githubusercontent.com/8244774/100855772-93978000-34b0-11eb-957d-226d40e55f6d.png)
