### PR TITLE
Disable edit and delete of UI read-only settings

### DIFF
--- a/src/components/view/DetailSettings.vue
+++ b/src/components/view/DetailSettings.vue
@@ -86,7 +86,10 @@
             <span v-else>{{ item.value }}</span>
           </span>
         </a-list-item-meta>
-        <div slot="actions" v-if="!disableSettings && 'updateTemplate' in $store.getters.apis && 'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner()">
+        <div
+          slot="actions"
+          v-if="!disableSettings && 'updateTemplate' in $store.getters.apis &&
+            'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner() && allowEditOfDetail(item.name)">
           <a-button shape="circle" size="default" @click="updateDetail(index)" v-if="item.edit">
             <a-icon type="check-circle" theme="twoTone" twoToneColor="#52c41a" />
           </a-button>
@@ -99,7 +102,10 @@
             v-if="!item.edit"
             @click="showEditDetail(index)" />
         </div>
-        <div slot="actions" v-if="!disableSettings && 'updateTemplate' in $store.getters.apis && 'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner()">
+        <div
+          slot="actions"
+          v-if="!disableSettings && 'updateTemplate' in $store.getters.apis &&
+            'updateVirtualMachine' in $store.getters.apis && isAdminOrOwner() && allowEditOfDetail(item.name)">
           <a-popconfirm
             :title="`${$t('label.delete.setting')}?`"
             @confirm="deleteDetail(index)"
@@ -169,6 +175,14 @@ export default {
         this.detailOptions = json.listdetailoptionsresponse.detailoptions.details
       })
       this.disableSettings = (this.$route.meta.name === 'vm' && this.resource.state !== 'Stopped')
+    },
+    allowEditOfDetail (name) {
+      if (this.resource.readonlyuidetails) {
+        if (this.resource.readonlyuidetails.split(',').map(item => item.trim()).includes(name)) {
+          return false
+        }
+      }
+      return true
     },
     showEditDetail (index) {
       this.details[index].edit = true


### PR DESCRIPTION
Added a setting - cpuNumber to the "user.vm.readonly.ui.details" global setting. Doing so should prevent a user from editing the value for the UI, however this isn't the case. This PR attempts to address this issue.

Legacy UI behavior:
![image](https://user-images.githubusercontent.com/10495417/101000417-e42bdd80-3583-11eb-9285-5c49010aecd7.png)

It disables the options to edit / delete the particular setting


Post Fix - Primate Behavior:
![image](https://user-images.githubusercontent.com/10495417/100998775-f278fa00-3581-11eb-97e5-482839c44798.png)

