### PR TITLE
Primary Storage: Fix empty server details for SharedMountPoint protocol

### DIFF
--- a/src/views/infra/AddPrimaryStorage.vue
+++ b/src/views/infra/AddPrimaryStorage.vue
@@ -601,6 +601,7 @@ export default {
             params['details[' + index.toString() + '].' + key] = smbParams[key]
           })
         } else if (values.protocol === 'PreSetup' && this.hypervisorType !== 'VMware') {
+          server = 'localhost'
           url = this.presetupURL(server, path)
         } else if (values.protocol === 'PreSetup' && this.hypervisorType === 'VMware') {
           path = values.vCenterDataCenter
@@ -619,6 +620,7 @@ export default {
         } else if (values.protocol === 'ocfs2') {
           url = this.ocfs2URL(server, path)
         } else if (values.protocol === 'SharedMountPoint') {
+          server = 'localhost'
           url = this.SharedMountPointURL(server, path)
         } else if (values.protocol === 'CLVM') {
           var vg = (values.volumegroup.substring(0, 1) !== '/') ? ('/' + values.volumegroup) : values.volumegroup


### PR DESCRIPTION
Addresses: https://github.com/apache/cloudstack-primate/issues/888
Selecting SharedMountPoint protocol while adding a Primary Store throws an error claiming the server detail is null:
![image](https://user-images.githubusercontent.com/10495417/101311348-3405ef80-3877-11eb-94d9-67f7097b8c35.png)

This PR fixes this by passing the server detail as localhost