### PR TITLE
Dont pass account/domainid for upload sslcert in project view

### DIFF
--- a/src/config/section/account.js
+++ b/src/config/section/account.js
@@ -160,15 +160,7 @@ export default {
       label: 'label.add.certificate',
       dataView: true,
       args: ['name', 'certificate', 'privatekey', 'certchain', 'password', 'account', 'domainid'],
-      show: (record) => { return record.state === 'enabled' },
-      mapping: {
-        account: {
-          value: (record) => { return record.name }
-        },
-        domainid: {
-          value: (record) => { return record.domainid }
-        }
-      }
+      show: (record) => { return record.state === 'enabled' }
     },
     {
       api: 'deleteAccount',


### PR DESCRIPTION
In project view, we can upload ssl certificate either by using
projectid or accountid/domainid combination. Since we are passing
all 3 parameters, we cant upload sslcert in project view


![Screenshot 2020-12-07 at 14 08 55](https://user-images.githubusercontent.com/10645273/101495700-203ab600-3969-11eb-9d5f-26fc4cf1684e.png)
