### PR TITLE
Add options for OOBM action commands

### DIFF
--- a/src/config/section/infra/hosts.js
+++ b/src/config/section/infra/hosts.js
@@ -192,6 +192,9 @@ export default {
       mapping: {
         hostid: {
           value: (record) => { return record.id }
+        },
+        action: {
+          options: ['ON', 'OFF', 'CYCLE', 'RESET', 'SOFT', 'STATUS']
         }
       }
     },


### PR DESCRIPTION
#### Description

Currently the UI allows to call OOBM actions, however, the ADMIN must fill a texbox with the command which might lead to issues in case the letters are not all capital or the command does not exist.

To help ADMINs, this PR adds an options list with the supported Action commands.

### Screenshot

![oobm-action](https://user-images.githubusercontent.com/5025148/101902625-bcdf9c80-3b91-11eb-8650-1e50672c7ebc.png)


### How this has been tested

Execute OOBM actions via the UI.