### PR TITLE
createnetwork: Fixing missing vlan parameter

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2222,6 +2222,7 @@
 "label.virtualmachinename": "VM name",
 "label.virtualsize": "Virtual Size",
 "label.vlan": "VLAN/VNI",
+"label.vlan.description": "The VLAN ID of the network",
 "label.vlan.range": "VLAN/VNI Range",
 "label.vlan.range.details": "VLAN Range details",
 "label.vlan.vni.ranges": "VLAN/VNI Range(s)",

--- a/src/views/network/CreateIsolatedNetworkForm.vue
+++ b/src/views/network/CreateIsolatedNetworkForm.vue
@@ -132,7 +132,7 @@
           <a-form-item v-if="!this.isObjectEmpty(this.selectedNetworkOffering) && this.selectedNetworkOffering.specifyvlan">
             <span slot="label">
               {{ $t('label.vlan') }}
-              <a-tooltip :title="apiParams.vlan.description">
+              <a-tooltip :title="this.$t('label.vlan.description')">
                 <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
               </a-tooltip>
             </span>

--- a/src/views/network/CreateL2NetworkForm.vue
+++ b/src/views/network/CreateL2NetworkForm.vue
@@ -132,7 +132,7 @@
           <a-form-item v-if="!this.isObjectEmpty(this.selectedNetworkOffering) && this.selectedNetworkOffering.specifyvlan">
             <span slot="label">
               {{ $t('label.vlan') }}
-              <a-tooltip :title="apiParams.vlan.description" v-if="'vlan' in apiParams">
+              <a-tooltip :title="this.$t('label.vlan.description')">
                 <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
               </a-tooltip>
             </span>

--- a/src/views/network/CreateNetwork.vue
+++ b/src/views/network/CreateNetwork.vue
@@ -18,15 +18,7 @@
 <template>
   <div class="form-layout">
     <a-tabs defaultActiveKey="1" :animated="false">
-      <a-tab-pane :tab="$t('label.isolated')" key="1" v-if="this.isAdvancedZoneWithoutSGAvailable()">
-        <CreateIsolatedNetworkForm
-          :loading="loading"
-          :resource="resource"
-          @close-action="closeAction"
-          @refresh-data="refreshParent"
-          @refresh="handleRefresh"/>
-      </a-tab-pane>
-      <a-tab-pane :tab="$t('label.l2')" key="2">
+      <a-tab-pane :tab="$t('label.l2')" key="1">
         <CreateL2NetworkForm
           :loading="loading"
           :resource="resource"
@@ -34,8 +26,16 @@
           @refresh-data="refreshParent"
           @refresh="handleRefresh"/>
       </a-tab-pane>
-      <a-tab-pane :tab="$t('label.shared')" key="3" v-if="this.isAdmin()">
+      <a-tab-pane :tab="$t('label.shared')" key="2" v-if="this.isAdmin()">
         <CreateSharedNetworkForm
+          :loading="loading"
+          :resource="resource"
+          @close-action="closeAction"
+          @refresh-data="refreshParent"
+          @refresh="handleRefresh"/>
+      </a-tab-pane>
+      <a-tab-pane :tab="$t('label.isolated')" key="3" v-if="this.isAdvancedZoneWithoutSGAvailable()">
+        <CreateIsolatedNetworkForm
           :loading="loading"
           :resource="resource"
           @close-action="closeAction"

--- a/src/views/network/CreateSharedNetworkForm.vue
+++ b/src/views/network/CreateSharedNetworkForm.vue
@@ -103,7 +103,7 @@
           <a-form-item>
             <span slot="label">
               {{ $t('label.vlan') }}
-              <a-tooltip :title="apiParams.vlan.description" v-if="'vlan' in apiParams">
+              <a-tooltip :title="this.$t('label.vlan.description')">
                 <a-icon type="info-circle" style="color: rgba(0,0,0,.45)" />
               </a-tooltip>
             </span>


### PR DESCRIPTION
Fixes inability to specify vlan for isolated networks

![Screenshot from 2020-12-14 11-35-27](https://user-images.githubusercontent.com/8244774/102046173-c4f14380-3e00-11eb-89f4-bb4afcc11a11.png)

Also reduces the issue when the isolated tab pops up seconds later