### PR TITLE
Fix label on Zone network setup step

### DIFF
--- a/src/views/infra/zone/ZoneWizardNetworkSetupStep.vue
+++ b/src/views/infra/zone/ZoneWizardNetworkSetupStep.vue
@@ -322,7 +322,7 @@ export default {
       },
       podSetupDescription: 'message.add.pod.during.zone.creation',
       netscalerSetupDescription: 'label.please.specify.netscaler.info',
-      storageTrafficDescription: 'label.zoneWizard.trafficType.management',
+      storageTrafficDescription: 'label.zonewizard.traffictype.storage',
       podFields: [
         {
           title: 'label.pod.name',


### PR DESCRIPTION
If a zone holds a storage network then the following label issue happens:

![image](https://user-images.githubusercontent.com/5025148/102231500-cc7e1e80-3ecc-11eb-8982-15ca0d043a0b.png)

After fixing the label:

![image](https://user-images.githubusercontent.com/5025148/102231793-2383f380-3ecd-11eb-84dd-066f30168e21.png)
