### PR TITLE
Fixes - Translation, notification, API request

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1934,6 +1934,8 @@
 "label.shrinkok": "Shrink OK",
 "label.shutdown.provider": "Shutdown provider",
 "label.simplified.chinese.keyboard": "Simplified Chinese keyboard",
+"label.s2scustomergatewayid": "Site to Site customer gateway ID",
+"label.s2svpngatewayid": "Site to Site VPN gateway ID",
 "label.site.to.site.vpn": "Site-to-site VPN",
 "label.site.to.site.vpn.connections": "Site-to-site VPN Connections",
 "label.size": "Size",

--- a/src/views/AutogenView.vue
+++ b/src/views/AutogenView.vue
@@ -996,7 +996,7 @@ export default {
         }
 
         const resourceName = params.displayname || params.displaytext || params.name || params.hostname || params.username ||
-          params.ipaddress || params.virtualmachinename || this.resource.name || this.resource.ipaddress
+          params.ipaddress || params.virtualmachinename || this.resource.name || this.resource.ipaddress || this.resource.id
 
         var hasJobId = false
         this.actionLoading = true

--- a/src/views/infra/AddPrimaryStorage.vue
+++ b/src/views/infra/AddPrimaryStorage.vue
@@ -593,8 +593,8 @@ export default {
         } else if (values.protocol === 'SMB') {
           url = this.smbURL(server, path)
           const smbParams = {
-            user: values.smbUsername,
-            password: values.smbPassword,
+            user: encodeURIComponent(values.smbUsername),
+            password: encodeURIComponent(values.smbPassword),
             domain: values.smbDomain
           }
           Object.keys(smbParams).forEach((key, index) => {
@@ -669,7 +669,7 @@ export default {
           params.tags = this.selectedTags.join()
         }
         this.loading = true
-        api('createStoragePool', params).then(json => {
+        api('createStoragePool', {}, 'POST', params).then(json => {
           this.$notification.success({
             message: this.$t('label.add.primary.storage'),
             description: this.$t('label.add.primary.storage')


### PR DESCRIPTION
Fixes around:
- missing translations for Site to site vpn form
- Undefined resource details in progress notification
![image](https://user-images.githubusercontent.com/10495417/102750554-08612a00-438c-11eb-8bfb-cf34371187e2.png)
Post fix:
![image](https://user-images.githubusercontent.com/10495417/102750662-36466e80-438c-11eb-90e6-8108357242a7.png)

- url encode smb username and password and change createStoragePool request from GET to POST