### PR TITLE
tools/docker: Change directory to docker.sh's directory

### DIFF
--- a/tools/docker.sh
+++ b/tools/docker.sh
@@ -19,6 +19,8 @@
 set -e
 set -x
 
+cd $(dirname $0)
+
 GIT_TAG="$(git tag --points-at | head -n 1)"
 if [ -n "${GIT_REV}" ]; then
 	LABEL_GIT_TAG="--label \"org.opencontainers.image.version=${GIT_TAG}\""


### PR DESCRIPTION
By switching to this directory we can use relative paths regardless
of how people execute the script.

cd tools
./docker.sh

OR

./tools/docker.sh

OR

/path/to/git-repo/tools/docker.sh